### PR TITLE
Fix: Tools panel color picker loses its listener on tool switch

### DIFF
--- a/bin/publish_to_cloudflare.sh
+++ b/bin/publish_to_cloudflare.sh
@@ -1,5 +1,9 @@
 #! /bin/bash
 
+echo "Check connection..."
+rclone lsd r2:apps-1kfa-com
+
+echo "Troubleshoot: Show Config with   rclone config show r2"
 
 echo "rclone sync ./src r2:apps-1kfa-com/table"
 rclone sync ./src r2:apps-1kfa-com/table

--- a/src/ui.js
+++ b/src/ui.js
@@ -354,7 +354,7 @@ export function onToolChanged(toolName) {
   renderPill();
   if (UIData.panelOpen === 'tools') {
     const body = $('#panelBody');
-    if (body) body.innerHTML = toolsBody(gatherToolsData());
+    if (body) { body.innerHTML = toolsBody(gatherToolsData()); wireColorPickers(body); }
   }
   if (toolName !== 'select') {
     const def = App.getTool(toolName);

--- a/tests/unit/ui.test.js
+++ b/tests/unit/ui.test.js
@@ -5,7 +5,7 @@
 
 // @vitest-environment jsdom
 import { describe, test, expect, vi, beforeEach } from 'vitest'
-import { layerObjectListHTML, refreshLayerList, UIData, init, toast, showBranchDialog, branchDialogJoin, branchDialogKeepWorking, peersBody, openSheet, closePanel, restorePanelState, histBody } from '../../src/ui.js'
+import { layerObjectListHTML, refreshLayerList, UIData, init, toast, showBranchDialog, branchDialogJoin, branchDialogKeepWorking, peersBody, openSheet, closePanel, restorePanelState, histBody, onToolChanged } from '../../src/ui.js'
 
 const mockObjects = [
   { id: 'a', label: 'rect',   fill: '#c8941e', kind: 'rect'   },
@@ -447,6 +447,37 @@ describe('onSelectionChanged handles all selection states', () => {
       expect(UIData.multiSelectionActive).toBe(true)
       expect(UIData.selectedCount).toBe(3)
     })
+  })
+})
+
+describe('onToolChanged — re-rendered Tools panel keeps its color picker wired', () => {
+  test('picking a color after switching tools calls App.setToolParam (regression: was missing wireColorPickers)', () => {
+    document.body.innerHTML = '<div id="panelBody"></div><div id="pill"></div>'
+    const setToolParam = vi.fn()
+    init({
+      getActiveLayer:        () => 'toys',
+      getTools:               () => [{ name: 'd6', label: 'D6' }],
+      getTool:                () => ({ label: 'D6' }),
+      getToolSchema:          () => ({ types: { fill: { kind: 'color-hsl', show: ['add', 'edit', 'addQuick'] } }, values: {} }),
+      getToolParams:          () => ({}),
+      getBackground:          () => ({}),
+      getDefaultBackgrounds:  () => [],
+      getToyClasses:          () => [],
+      setToolParam,
+    })
+    UIData.panelOpen = 'tools'
+
+    onToolChanged('d6')
+
+    const picker = document.querySelector('#panelBody color-picker')
+    expect(picker).not.toBeNull()
+    picker.dispatchEvent(new CustomEvent('color-picked', {
+      detail: { h: 0, s: 100, l: 50, a: 100, hex: '#ff0000', hex8: '#ff0000ff', rgba: 'rgba(255, 0, 0, 1.00)' },
+      bubbles: true,
+      composed: true,
+    }))
+
+    expect(setToolParam).toHaveBeenCalledWith('d6', 'fill', '#ff0000')
   })
 })
 


### PR DESCRIPTION
onToolChanged() re-rendered the Tools panel body on every tool change but never called wireColorPickers(), unlike every other re-render site (openSheet, refreshFromDoc). The freshly-created <color-picker> element had no 'color-picked' listener, so picking a color right after selecting a tool (e.g. clicking d6, then choosing red) never reached App.setToolParam — the die got placed with its default fill, and the next doc-triggered panel refresh showed the picker back at that default, looking like it had "reset to white".