### PR TITLE
Fix Edit-panel range dragging with a ghost-preview strategy

### DIFF
--- a/src/app.js
+++ b/src/app.js
@@ -1237,12 +1237,12 @@ const App = {
     // Refresh the Edit panel body to show the updated values.
     UI.refreshFromDoc();
     // Ghost ends after the commit — same ordering requirement as
-    // commitResize: endAttrGhost's own render() paints whatever the DOM
+    // commitResize: endGhost's own render() paints whatever the DOM
     // currently shows, so it has to run after the real change lands. A
     // no-op whenever this id has no active preview (see previewEdit) —
     // every commitEdit call clears one if there is one, so callers never
     // need to remember to do it themselves.
-    Overlay.endAttrGhost(id);
+    Overlay.endGhost(id);
   },
 
   // ── Edit-panel live preview (ghost, no Yjs write) ─────────────────────────
@@ -1256,10 +1256,17 @@ const App = {
   // including the very <range-ticked> element the user has their mouse on
   // mid-drag, killing the browser's native slider-drag tracking on it.
   // previewEdit instead only mutates a detached ghost clone on the Overlay
-  // layer (Overlay.startAttrGhost/updateAttrGhost — see overlay.js for why
-  // a clone, not the real element); #panelBody is never touched until the
+  // layer (Overlay.startGhost/updateGhost — see overlay.js for why a
+  // clone, not the real element); #panelBody is never touched until the
   // caller's own commitEdit(id, editData) call writes the real change, at
   // gesture end.
+  //
+  // App itself has no idea how a given editData applies to a given
+  // element's ghost — that's each layer module's own business (e.g. only
+  // boun_pos.js knows a position-set's circles are derived from spacing;
+  // only drawing.js knows its schema-key -> SVG-attribute aliases). This
+  // just finds the ghost's layer and hands the clone to its
+  // previewEdit(ghostEl, editData).
   //
   // lifecycle: previewEdit (every tick, lazily starts the ghost on the
   //            first call) / commitEdit (once, on release — see above,
@@ -1269,43 +1276,15 @@ const App = {
     const domEl = _svgEl?.querySelector(`[data-id="${id}"]`);
     if (!domEl) return;
     const mtype = moduleForElement(domEl);
-    Overlay.startAttrGhost(id);
-
-    // boun_pos position-sets don't have a single attribute to preview —
-    // snapRadius/xSpacing/ySpacing each recompute the whole snap-point
-    // grid (see boun_pos.js's computeGridPositions, the same math the
-    // real commit path uses). Read whichever of the three aren't present
-    // in editData off the live element (getTtStateSchema already derives
-    // them from its data-gen-*/data-snap-radius attributes) so previewing
-    // just one still shows a real grid, not a guess at the other two.
-    if (mtype === 'boun_pos' && domEl.getAttribute('data-bounpos-type') === 'pos-set' &&
-        (editData.xSpacing !== undefined || editData.ySpacing !== undefined || editData.snapRadius !== undefined)) {
-      const current   = BounPos.getTtStateSchema(domEl);
-      const genType    = domEl.getAttribute('data-gen-type') ?? 'square';
-      const xSpacing   = editData.xSpacing   ?? current.xSpacing;
-      const ySpacing   = editData.ySpacing   ?? current.ySpacing;
-      const snapRLevel = editData.snapRadius ?? current.snapRadius;
-      const { x, y, width: w, height: h } = BounPos.getGeom(domEl) ?? {};
-      const { circles, r } = BounPos.computeGridPositions({ x, y, w, h }, genType, xSpacing, ySpacing, snapRLevel);
-      Overlay.updatePosSetGhost(id, circles, r);
-      return;
-    }
-
-    // Only drawing shapes have a schema-key -> SVG-attribute alias (e.g.
-    // corner-r -> rx — see drawing.js's SHAPE_TYPES attrMap); everywhere
-    // else the schema key already is the attribute name.
-    for (const [key, value] of Object.entries(editData)) {
-      const svgAttr = mtype === 'drawing'
-        ? (Drawing.SHAPE_TYPES[domEl.tagName]?.attrMap?.[key] ?? key)
-        : key;
-      Overlay.updateAttrGhost(id, svgAttr, value);
-    }
+    const L = _Layers[mtype];
+    Overlay.startGhost(id);
+    Overlay.updateGhost(id, (ghostEl) => L?.previewEdit?.(ghostEl, editData));
   },
 
   // Discard an in-progress preview without writing anything — Overlay.
-  // endAttrGhost is already a no-op if there's nothing to discard, so this
+  // endGhost is already a no-op if there's nothing to discard, so this
   // needs no bookkeeping of its own.
-  cancelEdit: (id) => Overlay.endAttrGhost(id),
+  cancelEdit: (id) => Overlay.endGhost(id),
 
   /**
    * Place a toy on the table, then run its namespace(s)' initialize(elem)

--- a/src/app.js
+++ b/src/app.js
@@ -1266,19 +1266,34 @@ const App = {
     const domEl = _svgEl?.querySelector(`[data-id="${id}"]`);
     if (!domEl) return;
     const mtype = moduleForElement(domEl);
+    _fieldPreviewState = { id, key, mtype };
+    Overlay.startAttrGhost(id);
+
+    // boun_pos position-sets don't have a single attribute to preview —
+    // snapRadius/xSpacing/ySpacing each recompute the whole snap-point
+    // grid (see boun_pos.js's computeGridPositions, the same math the
+    // real commit path uses). Read the OTHER two current values off the
+    // live element (getTtStateSchema already derives them from its
+    // data-gen-*/data-snap-radius attributes) so dragging one field
+    // previews a real grid, not a guess at the other two.
+    if (mtype === 'boun_pos' && domEl.getAttribute('data-bounpos-type') === 'pos-set') {
+      const current   = BounPos.getTtStateSchema(domEl);
+      const genType    = domEl.getAttribute('data-gen-type') ?? 'square';
+      const xSpacing   = key === 'xSpacing'   ? value : current.xSpacing;
+      const ySpacing   = key === 'ySpacing'   ? value : current.ySpacing;
+      const snapRLevel = key === 'snapRadius' ? value : current.snapRadius;
+      const { x, y, width: w, height: h } = BounPos.getGeom(domEl) ?? {};
+      const { circles, r } = BounPos.computeGridPositions({ x, y, w, h }, genType, xSpacing, ySpacing, snapRLevel);
+      Overlay.updatePosSetGhost(id, circles, r);
+      return;
+    }
+
     // Only drawing shapes have a schema-key -> SVG-attribute alias (e.g.
     // corner-r -> rx — see drawing.js's SHAPE_TYPES attrMap); everywhere
-    // else the schema key already is the attribute name. Ghost-previewing
-    // a field with no such direct attribute (e.g. boun_pos's snapRadius,
-    // which recomputes several nested circles) is a harmless no-op here —
-    // the clone just doesn't visually change — but this call still fixes
-    // the actual bug for those fields too, since it's still the only
-    // thing standing between the drag and a per-tick Yjs write.
+    // else the schema key already is the attribute name.
     const svgAttr = mtype === 'drawing'
       ? (Drawing.SHAPE_TYPES[domEl.tagName]?.attrMap?.[key] ?? key)
       : key;
-    _fieldPreviewState = { id, key, mtype };
-    Overlay.startAttrGhost(id);
     Overlay.updateAttrGhost(id, svgAttr, value);
   },
 

--- a/src/app.js
+++ b/src/app.js
@@ -1236,41 +1236,10 @@ const App = {
     // observeDeep fires synchronously
     // Refresh the Edit panel body to show the updated values.
     UI.refreshFromDoc();
-    // Ghost ends after the commit — same ordering requirement as
-    // commitResize: endGhost's own render() paints whatever the DOM
-    // currently shows, so it has to run after the real change lands. A
-    // no-op whenever this id has no active preview (see previewEdit) —
-    // every commitEdit call clears one if there is one, so callers never
-    // need to remember to do it themselves.
+    // endGhost's render() paints current DOM state, so it must run
+    // after the real change lands
     Overlay.endGhost(id);
   },
-
-  // ── Edit-panel live preview (ghost, no Yjs write) ─────────────────────────
-  // Same shape as the resize lifecycle above (startResize/resize/
-  // commitResize/cancelResize), and the same editData an ordinary
-  // commitEdit(id, editData) takes — this just doesn't write it yet. A
-  // live-updating Edit panel field (currently just range-ticked sliders —
-  // see ui.js's wireRangeTicked 'edit' branch) would otherwise call
-  // commitEdit on every tick, and commitEdit's UI.refreshFromDoc() rebuilds
-  // #panelBody's whole innerHTML synchronously on every one of those —
-  // including the very <range-ticked> element the user has their mouse on
-  // mid-drag, killing the browser's native slider-drag tracking on it.
-  // previewEdit instead only mutates a detached ghost clone on the Overlay
-  // layer (Overlay.startGhost/updateGhost — see overlay.js for why a
-  // clone, not the real element); #panelBody is never touched until the
-  // caller's own commitEdit(id, editData) call writes the real change, at
-  // gesture end.
-  //
-  // App itself has no idea how a given editData applies to a given
-  // element's ghost — that's each layer module's own business (e.g. only
-  // boun_pos.js knows a position-set's circles are derived from spacing;
-  // only drawing.js knows its schema-key -> SVG-attribute aliases). This
-  // just finds the ghost's layer and hands the clone to its
-  // previewEdit(ghostEl, editData).
-  //
-  // lifecycle: previewEdit (every tick, lazily starts the ghost on the
-  //            first call) / commitEdit (once, on release — see above,
-  //            it ends the ghost itself) / cancelEdit (discard, no write)
 
   previewEdit: (id, editData) => {
     const domEl = _svgEl?.querySelector(`[data-id="${id}"]`);
@@ -1278,12 +1247,10 @@ const App = {
     const mtype = moduleForElement(domEl);
     const L = _Layers[mtype];
     Overlay.startGhost(id);
-    Overlay.updateGhost(id, (ghostEl) => L?.previewEdit?.(ghostEl, editData));
+    Overlay.updateGhost(id, (ghostEl) => L.previewEdit(ghostEl, editData));
   },
 
-  // Discard an in-progress preview without writing anything — Overlay.
-  // endGhost is already a no-op if there's nothing to discard, so this
-  // needs no bookkeeping of its own.
+  // Discard an in-progress preview without writing anything
   cancelEdit: (id) => Overlay.endGhost(id),
 
   /**

--- a/src/app.js
+++ b/src/app.js
@@ -288,6 +288,12 @@ let _multiDragState = null;  // { elements: [{ id, mtype, anchorX, anchorY, bbox
 let _resizeState = null;    // { id, corner, startRect: {x,y,width,height},
                             //   lastRect: {x,y,width,height} } | null
 
+// Active Edit-panel field preview (see App.previewField). Mirrors
+// _resizeState's role: bookkeeping for cancelFieldPreview, not required
+// for the ghost's own idempotency (Overlay.startAttrGhost already no-ops
+// once a ghost exists for an id).
+let _fieldPreviewState = null; // { id, key, mtype } | null
+
 // Which undo mechanism App.undo/App.redo should invoke: the toys op log
 // (Toys.undoToyGesture) or the drawing/boundaries Y.UndoManager
 // (UndoRedo.undo). Set at every commit callsite to whichever the action
@@ -1236,6 +1242,59 @@ const App = {
     // observeDeep fires synchronously
     // Refresh the Edit panel body to show the updated values.
     UI.refreshFromDoc();
+  },
+
+  // ── Edit-panel field preview (ghost, no Yjs write) ────────────────────────
+  // Same shape as the resize lifecycle above (startResize/resize/
+  // commitResize/cancelResize): a live-updating Edit panel field (currently
+  // just range-ticked sliders — see ui.js's wireRangeTicked 'edit' branch)
+  // would otherwise call commitEdit on every tick, and commitEdit's
+  // UI.refreshFromDoc() rebuilds #panelBody's whole innerHTML synchronously
+  // on every one of those — including the very <range-ticked> element the
+  // user has their mouse on mid-drag, killing the browser's native
+  // slider-drag tracking on it. previewField instead only mutates a
+  // detached ghost clone on the Overlay layer (Overlay.startAttrGhost/
+  // updateAttrGhost — see overlay.js for why a clone, not the real
+  // element); #panelBody is never touched until commitFieldPreview writes
+  // the real Yjs change once, at gesture end.
+  //
+  // lifecycle: previewField (every tick, lazily starts the ghost on the
+  //            first call) / commitFieldPreview (once, on release) /
+  //            cancelFieldPreview (discard, no Yjs write)
+
+  previewField: (id, key, value) => {
+    const domEl = _svgEl?.querySelector(`[data-id="${id}"]`);
+    if (!domEl) return;
+    const mtype = moduleForElement(domEl);
+    // Only drawing shapes have a schema-key -> SVG-attribute alias (e.g.
+    // corner-r -> rx — see drawing.js's SHAPE_TYPES attrMap); everywhere
+    // else the schema key already is the attribute name. Ghost-previewing
+    // a field with no such direct attribute (e.g. boun_pos's snapRadius,
+    // which recomputes several nested circles) is a harmless no-op here —
+    // the clone just doesn't visually change — but this call still fixes
+    // the actual bug for those fields too, since it's still the only
+    // thing standing between the drag and a per-tick Yjs write.
+    const svgAttr = mtype === 'drawing'
+      ? (Drawing.SHAPE_TYPES[domEl.tagName]?.attrMap?.[key] ?? key)
+      : key;
+    _fieldPreviewState = { id, key, mtype };
+    Overlay.startAttrGhost(id);
+    Overlay.updateAttrGhost(id, svgAttr, value);
+  },
+
+  commitFieldPreview: (id, key, value) => {
+    _fieldPreviewState = null;
+    App.commitEdit(id, { [key]: value });
+    // Ghost ends after the commit — same ordering requirement as
+    // commitResize: endAttrGhost's own render() paints whatever the DOM
+    // currently shows, so it has to run after the real change lands.
+    Overlay.endAttrGhost(id);
+  },
+
+  cancelFieldPreview: (id) => {
+    if (!_fieldPreviewState || _fieldPreviewState.id !== id) return;
+    _fieldPreviewState = null;
+    Overlay.endAttrGhost(id);
   },
 
   /**

--- a/src/app.js
+++ b/src/app.js
@@ -288,12 +288,6 @@ let _multiDragState = null;  // { elements: [{ id, mtype, anchorX, anchorY, bbox
 let _resizeState = null;    // { id, corner, startRect: {x,y,width,height},
                             //   lastRect: {x,y,width,height} } | null
 
-// Active Edit-panel field preview (see App.previewField). Mirrors
-// _resizeState's role: bookkeeping for cancelFieldPreview, not required
-// for the ghost's own idempotency (Overlay.startAttrGhost already no-ops
-// once a ghost exists for an id).
-let _fieldPreviewState = null; // { id, key, mtype } | null
-
 // Which undo mechanism App.undo/App.redo should invoke: the toys op log
 // (Toys.undoToyGesture) or the drawing/boundaries Y.UndoManager
 // (UndoRedo.undo). Set at every commit callsite to whichever the action
@@ -1242,46 +1236,55 @@ const App = {
     // observeDeep fires synchronously
     // Refresh the Edit panel body to show the updated values.
     UI.refreshFromDoc();
+    // Ghost ends after the commit — same ordering requirement as
+    // commitResize: endAttrGhost's own render() paints whatever the DOM
+    // currently shows, so it has to run after the real change lands. A
+    // no-op whenever this id has no active preview (see previewEdit) —
+    // every commitEdit call clears one if there is one, so callers never
+    // need to remember to do it themselves.
+    Overlay.endAttrGhost(id);
   },
 
-  // ── Edit-panel field preview (ghost, no Yjs write) ────────────────────────
+  // ── Edit-panel live preview (ghost, no Yjs write) ─────────────────────────
   // Same shape as the resize lifecycle above (startResize/resize/
-  // commitResize/cancelResize): a live-updating Edit panel field (currently
-  // just range-ticked sliders — see ui.js's wireRangeTicked 'edit' branch)
-  // would otherwise call commitEdit on every tick, and commitEdit's
-  // UI.refreshFromDoc() rebuilds #panelBody's whole innerHTML synchronously
-  // on every one of those — including the very <range-ticked> element the
-  // user has their mouse on mid-drag, killing the browser's native
-  // slider-drag tracking on it. previewField instead only mutates a
-  // detached ghost clone on the Overlay layer (Overlay.startAttrGhost/
-  // updateAttrGhost — see overlay.js for why a clone, not the real
-  // element); #panelBody is never touched until commitFieldPreview writes
-  // the real Yjs change once, at gesture end.
+  // commitResize/cancelResize), and the same editData an ordinary
+  // commitEdit(id, editData) takes — this just doesn't write it yet. A
+  // live-updating Edit panel field (currently just range-ticked sliders —
+  // see ui.js's wireRangeTicked 'edit' branch) would otherwise call
+  // commitEdit on every tick, and commitEdit's UI.refreshFromDoc() rebuilds
+  // #panelBody's whole innerHTML synchronously on every one of those —
+  // including the very <range-ticked> element the user has their mouse on
+  // mid-drag, killing the browser's native slider-drag tracking on it.
+  // previewEdit instead only mutates a detached ghost clone on the Overlay
+  // layer (Overlay.startAttrGhost/updateAttrGhost — see overlay.js for why
+  // a clone, not the real element); #panelBody is never touched until the
+  // caller's own commitEdit(id, editData) call writes the real change, at
+  // gesture end.
   //
-  // lifecycle: previewField (every tick, lazily starts the ghost on the
-  //            first call) / commitFieldPreview (once, on release) /
-  //            cancelFieldPreview (discard, no Yjs write)
+  // lifecycle: previewEdit (every tick, lazily starts the ghost on the
+  //            first call) / commitEdit (once, on release — see above,
+  //            it ends the ghost itself) / cancelEdit (discard, no write)
 
-  previewField: (id, key, value) => {
+  previewEdit: (id, editData) => {
     const domEl = _svgEl?.querySelector(`[data-id="${id}"]`);
     if (!domEl) return;
     const mtype = moduleForElement(domEl);
-    _fieldPreviewState = { id, key, mtype };
     Overlay.startAttrGhost(id);
 
     // boun_pos position-sets don't have a single attribute to preview —
     // snapRadius/xSpacing/ySpacing each recompute the whole snap-point
     // grid (see boun_pos.js's computeGridPositions, the same math the
-    // real commit path uses). Read the OTHER two current values off the
-    // live element (getTtStateSchema already derives them from its
-    // data-gen-*/data-snap-radius attributes) so dragging one field
-    // previews a real grid, not a guess at the other two.
-    if (mtype === 'boun_pos' && domEl.getAttribute('data-bounpos-type') === 'pos-set') {
+    // real commit path uses). Read whichever of the three aren't present
+    // in editData off the live element (getTtStateSchema already derives
+    // them from its data-gen-*/data-snap-radius attributes) so previewing
+    // just one still shows a real grid, not a guess at the other two.
+    if (mtype === 'boun_pos' && domEl.getAttribute('data-bounpos-type') === 'pos-set' &&
+        (editData.xSpacing !== undefined || editData.ySpacing !== undefined || editData.snapRadius !== undefined)) {
       const current   = BounPos.getTtStateSchema(domEl);
       const genType    = domEl.getAttribute('data-gen-type') ?? 'square';
-      const xSpacing   = key === 'xSpacing'   ? value : current.xSpacing;
-      const ySpacing   = key === 'ySpacing'   ? value : current.ySpacing;
-      const snapRLevel = key === 'snapRadius' ? value : current.snapRadius;
+      const xSpacing   = editData.xSpacing   ?? current.xSpacing;
+      const ySpacing   = editData.ySpacing   ?? current.ySpacing;
+      const snapRLevel = editData.snapRadius ?? current.snapRadius;
       const { x, y, width: w, height: h } = BounPos.getGeom(domEl) ?? {};
       const { circles, r } = BounPos.computeGridPositions({ x, y, w, h }, genType, xSpacing, ySpacing, snapRLevel);
       Overlay.updatePosSetGhost(id, circles, r);
@@ -1291,26 +1294,18 @@ const App = {
     // Only drawing shapes have a schema-key -> SVG-attribute alias (e.g.
     // corner-r -> rx — see drawing.js's SHAPE_TYPES attrMap); everywhere
     // else the schema key already is the attribute name.
-    const svgAttr = mtype === 'drawing'
-      ? (Drawing.SHAPE_TYPES[domEl.tagName]?.attrMap?.[key] ?? key)
-      : key;
-    Overlay.updateAttrGhost(id, svgAttr, value);
+    for (const [key, value] of Object.entries(editData)) {
+      const svgAttr = mtype === 'drawing'
+        ? (Drawing.SHAPE_TYPES[domEl.tagName]?.attrMap?.[key] ?? key)
+        : key;
+      Overlay.updateAttrGhost(id, svgAttr, value);
+    }
   },
 
-  commitFieldPreview: (id, key, value) => {
-    _fieldPreviewState = null;
-    App.commitEdit(id, { [key]: value });
-    // Ghost ends after the commit — same ordering requirement as
-    // commitResize: endAttrGhost's own render() paints whatever the DOM
-    // currently shows, so it has to run after the real change lands.
-    Overlay.endAttrGhost(id);
-  },
-
-  cancelFieldPreview: (id) => {
-    if (!_fieldPreviewState || _fieldPreviewState.id !== id) return;
-    _fieldPreviewState = null;
-    Overlay.endAttrGhost(id);
-  },
+  // Discard an in-progress preview without writing anything — Overlay.
+  // endAttrGhost is already a no-op if there's nothing to discard, so this
+  // needs no bookkeeping of its own.
+  cancelEdit: (id) => Overlay.endAttrGhost(id),
 
   /**
    * Place a toy on the table, then run its namespace(s)' initialize(elem)

--- a/src/boun_pos.js
+++ b/src/boun_pos.js
@@ -83,7 +83,7 @@ export function toolParamsToCreateParams(genType, toolParams, {x, y, w, h}) {
  * level (1-4) — the same math rebuildPositionSetGrid uses to actually
  * commit a grid resize. Exposed separately (pure, no Yjs) so a live
  * preview can compute the identical result without writing anything —
- * see overlay.js's updatePosSetGhost and app.js's previewField.
+ * see overlay.js's updatePosSetGhost and app.js's previewEdit.
  */
 export function computeGridPositions(extent, genType, xSpacing, ySpacing, snapRadiusLevel) {
   const { x, y, w, h } = extent;

--- a/src/boun_pos.js
+++ b/src/boun_pos.js
@@ -80,10 +80,9 @@ export function toolParamsToCreateParams(genType, toolParams, {x, y, w, h}) {
 /**
  * Compute the circle positions + shared radius for genType/xSpacing/
  * ySpacing within an extent rect ({x,y,w,h}), at the given snapRadius
- * level (1-4) — the same math rebuildPositionSetGrid uses to actually
- * commit a grid resize. Exposed separately (pure, no Yjs) so a live
- * preview can compute the identical result without writing anything —
- * see this file's own previewEdit, below.
+ * level (1-4)
+ * Exposed separately (pure, no Yjs) so a live preview can compute the
+ * identical result without writing anything
  */
 export function computeGridPositions(extent, genType, xSpacing, ySpacing, snapRadiusLevel) {
   const { x, y, w, h } = extent;
@@ -966,18 +965,9 @@ export function editEl(ydoc, yEl, editData) {
 }
 
 /**
- * Preview an edit on a detached ghost clone (see overlay.js's ghost
- * system, used via App.previewEdit) — mutates ghostEl directly, never
- * touches Yjs. Only pos-sets have anything to preview here, and only for
- * snapRadius/xSpacing/ySpacing: unlike a plain attribute tweak, each of
- * those recomputes the whole snap-point grid (a variable number of
- * <circle> children), using the exact math editEl's real commit path
- * uses (computeGridPositions) — so this is the one place outside editEl
- * that needs to know a pos-set even HAS circles, let alone how many or
- * where. Whichever of the three keys aren't present in editData are read
- * off ghostEl's own current attributes (getTtStateSchema works on any
- * element carrying the right data-gen-… / data-snap-radius attributes, a
- * ghost clone included), so previewing just one still shows a real grid.
+ * Preview an edit on a detached ghost clone
+ * Whichever of the three keys aren't present in editData are read
+ * off ghostEl's own current attributes
  */
 export function previewEdit(ghostEl, editData) {
   if (ghostEl.getAttribute('data-bounpos-type') !== 'pos-set') return;
@@ -995,10 +985,8 @@ export function previewEdit(ghostEl, editData) {
     genType, xSpacing, ySpacing, snapRadiusLevel
   );
 
-  // Reuse the first existing circle as a template (preserving its fill —
-  // the snap-point gradient — and any other authored attributes) for
-  // every new position; falls back to a bare circle only if the ghost
-  // started with none at all.
+  // Reuse the first existing circle as a template
+  // falls back to a bare circle only if the ghost started with none at all.
   const existing = [...ghostEl.querySelectorAll(':scope > circle')];
   const template = existing[0] ?? null;
   for (const c of existing) c.remove();

--- a/src/boun_pos.js
+++ b/src/boun_pos.js
@@ -77,13 +77,27 @@ export function toolParamsToCreateParams(genType, toolParams, {x, y, w, h}) {
   return { snapRadius, xSpacing, ySpacing, circles }
 }
 
+/**
+ * Compute the circle positions + shared radius for genType/xSpacing/
+ * ySpacing within an extent rect ({x,y,w,h}), at the given snapRadius
+ * level (1-4) — the same math rebuildPositionSetGrid uses to actually
+ * commit a grid resize. Exposed separately (pure, no Yjs) so a live
+ * preview can compute the identical result without writing anything —
+ * see overlay.js's updatePosSetGhost and app.js's previewField.
+ */
+export function computeGridPositions(extent, genType, xSpacing, ySpacing, snapRadiusLevel) {
+  const { x, y, w, h } = extent;
+  const circles = gridFillExtent(x, y, w, h, genType, xSpacing, ySpacing);
+  const r = snapRadiusLevelToRadius(snapRadiusLevel ?? 2, genType, xSpacing, ySpacing);
+  return { circles, r };
+}
+
 function rebuildPositionSetGrid(ydoc, yEl, { genType, xSpacing, ySpacing, snapRadiusLevel }) {
   const yPath = yChildByTag(yEl, 'path');
   if (!yPath) return;
 
-  const { x, y, w, h } = pathToRect(yPath.getAttribute('d') ?? 'M0,0 L100,0 L100,100 L0,100 Z');
-  const circles = gridFillExtent(x, y, w, h, genType, xSpacing, ySpacing);
-  const r = snapRadiusLevelToRadius(snapRadiusLevel ?? 2, genType, xSpacing, ySpacing);
+  const extent = pathToRect(yPath.getAttribute('d') ?? 'M0,0 L100,0 L100,100 L0,100 Z');
+  const { circles, r } = computeGridPositions(extent, genType, xSpacing, ySpacing, snapRadiusLevel);
 
   ydoc.transact(() => {
     yEl.setAttribute('data-gen-type',      genType);

--- a/src/boun_pos.js
+++ b/src/boun_pos.js
@@ -83,7 +83,7 @@ export function toolParamsToCreateParams(genType, toolParams, {x, y, w, h}) {
  * level (1-4) — the same math rebuildPositionSetGrid uses to actually
  * commit a grid resize. Exposed separately (pure, no Yjs) so a live
  * preview can compute the identical result without writing anything —
- * see overlay.js's updatePosSetGhost and app.js's previewEdit.
+ * see this file's own previewEdit, below.
  */
 export function computeGridPositions(extent, genType, xSpacing, ySpacing, snapRadiusLevel) {
   const { x, y, w, h } = extent;
@@ -964,6 +964,53 @@ export function editEl(ydoc, yEl, editData) {
     });
   }
 }
+
+/**
+ * Preview an edit on a detached ghost clone (see overlay.js's ghost
+ * system, used via App.previewEdit) — mutates ghostEl directly, never
+ * touches Yjs. Only pos-sets have anything to preview here, and only for
+ * snapRadius/xSpacing/ySpacing: unlike a plain attribute tweak, each of
+ * those recomputes the whole snap-point grid (a variable number of
+ * <circle> children), using the exact math editEl's real commit path
+ * uses (computeGridPositions) — so this is the one place outside editEl
+ * that needs to know a pos-set even HAS circles, let alone how many or
+ * where. Whichever of the three keys aren't present in editData are read
+ * off ghostEl's own current attributes (getTtStateSchema works on any
+ * element carrying the right data-gen-… / data-snap-radius attributes, a
+ * ghost clone included), so previewing just one still shows a real grid.
+ */
+export function previewEdit(ghostEl, editData) {
+  if (ghostEl.getAttribute('data-bounpos-type') !== 'pos-set') return;
+  if (editData.xSpacing === undefined && editData.ySpacing === undefined && editData.snapRadius === undefined) return;
+
+  const current = getTtStateSchema(ghostEl);
+  const genType = ghostEl.getAttribute('data-gen-type') ?? 'square';
+  const xSpacing        = editData.xSpacing   ?? current.xSpacing;
+  const ySpacing        = editData.ySpacing   ?? current.ySpacing;
+  const snapRadiusLevel = editData.snapRadius ?? current.snapRadius;
+  const extent = getGeom(ghostEl);
+  if (!extent) return;
+  const { circles, r } = computeGridPositions(
+    { x: extent.x, y: extent.y, w: extent.width, h: extent.height },
+    genType, xSpacing, ySpacing, snapRadiusLevel
+  );
+
+  // Reuse the first existing circle as a template (preserving its fill —
+  // the snap-point gradient — and any other authored attributes) for
+  // every new position; falls back to a bare circle only if the ghost
+  // started with none at all.
+  const existing = [...ghostEl.querySelectorAll(':scope > circle')];
+  const template = existing[0] ?? null;
+  for (const c of existing) c.remove();
+  for (const { cx, cy } of circles) {
+    const circle = template ? template.cloneNode(true) : document.createElementNS(SVG_NS, 'circle');
+    circle.setAttribute('cx', Math.round(cx));
+    circle.setAttribute('cy', Math.round(cy));
+    circle.setAttribute('r',  Math.round(r));
+    ghostEl.appendChild(circle);
+  }
+}
+
 // ── Drag context helpers ──────────────────────────────────────────────────────
 
 /**
@@ -1027,6 +1074,7 @@ export function makeLayerAPI(ydoc, yBounPos) {
     applyMoveCommit:  (yEl, x, y)        => applyMoveCommit(ydoc, yEl, x, y),
     applyTtState:     (state)            => applyTtState(ydoc, yBounPos, state),
     edit:             (yEl, editData)    => editEl(ydoc, yEl, editData),
+    previewEdit,
     listData:         ()                 => layerData(yBounPos),
     render:           (layerEl)          => render(yBounPos, layerEl),
   };

--- a/src/component/RANGE_TICKED_README.md
+++ b/src/component/RANGE_TICKED_README.md
@@ -92,6 +92,27 @@ el.addEventListener('range-changed', (event) => {
 }
 ```
 
+### `range-committed`
+
+Emitted once when the gesture actually ends — the native `change` event
+under the hood, which fires on mouse release (not on every drag tick) or
+after a keyboard nudge. Same detail shape as `range-changed`.
+
+Use this instead of `range-changed` for anything that should only happen
+once per interaction rather than on every tick — most importantly, writing
+to a shared or synced data store. Committing on every `input` tick and
+having that trigger a re-render of an ancestor containing this element
+will tear down and rebuild the live `<input>` out from under an
+in-progress drag, breaking the browser's own drag tracking on it (see
+"Why `value` gets a cheap update path" below — this is the same failure
+mode one level up, and `range-committed` exists so a consumer doesn't have
+to reinvent input-vs-change debouncing to avoid it).
+
+```javascript
+el.addEventListener('range-changed', (e) => updateLocalPreview(e.detail.value));
+el.addEventListener('range-committed', (e) => saveToServer(e.detail.value));
+```
+
 ## Examples
 
 ### A 1-25 die-style value picker

--- a/src/component/range_ticked.js
+++ b/src/component/range_ticked.js
@@ -26,6 +26,9 @@
  *
  * @fires range-changed - Emitted on every 'input' tick of the drag
  *   Detail: {value: number}
+ * @fires range-committed - Emitted once when the gesture ends (native
+ *   'change' — mouse released, or a keyboard nudge's own press-and-commit).
+ *   Detail: {value: number}
  */
 class RangeTicked extends HTMLElement {
   constructor() {
@@ -170,6 +173,14 @@ class RangeTicked extends HTMLElement {
       this.setAttribute('value', this._input.value);
       this.emitChange();
     });
+    // Native 'change' fires once per gesture (mouse released, or a
+    // keyboard nudge's own atomic press-and-commit) — unlike 'input',
+    // which fires continuously while dragging. A consumer that wants to
+    // defer a heavier commit (e.g. writing to a shared/synced document)
+    // until the interaction is actually finished, rather than on every
+    // drag tick, should listen for 'range-committed' instead of
+    // 'range-changed'.
+    this._input.addEventListener('change', () => this.emitCommit());
   }
 
   /**
@@ -200,6 +211,14 @@ class RangeTicked extends HTMLElement {
 
   emitChange() {
     this.dispatchEvent(new CustomEvent('range-changed', {
+      detail: { value: Number(this._input.value) },
+      bubbles: true,
+      composed: true,
+    }));
+  }
+
+  emitCommit() {
+    this.dispatchEvent(new CustomEvent('range-committed', {
       detail: { value: Number(this._input.value) },
       bubbles: true,
       composed: true,

--- a/src/drawing.js
+++ b/src/drawing.js
@@ -454,14 +454,6 @@ export function edit(ydoc, yEl, editData) {
   });
 }
 
-/**
- * Preview an edit on a detached ghost clone (see overlay.js's ghost
- * system, used via App.previewEdit) — mutates ghostEl's own attributes
- * directly, never touches Yjs. Translates a schema key through its
- * attrMap alias (e.g. corner-r -> rx) the same way addDrawing applies it
- * at creation time, since the ghost is a real rendered element (a clone)
- * and only understands actual SVG attribute names.
- */
 export function previewEdit(ghostEl, editData) {
   const attrMap = SHAPE_TYPES[ghostEl.tagName]?.attrMap ?? {};
   for (const [key, value] of Object.entries(editData)) {

--- a/src/drawing.js
+++ b/src/drawing.js
@@ -455,6 +455,21 @@ export function edit(ydoc, yEl, editData) {
 }
 
 /**
+ * Preview an edit on a detached ghost clone (see overlay.js's ghost
+ * system, used via App.previewEdit) — mutates ghostEl's own attributes
+ * directly, never touches Yjs. Translates a schema key through its
+ * attrMap alias (e.g. corner-r -> rx) the same way addDrawing applies it
+ * at creation time, since the ghost is a real rendered element (a clone)
+ * and only understands actual SVG attribute names.
+ */
+export function previewEdit(ghostEl, editData) {
+  const attrMap = SHAPE_TYPES[ghostEl.tagName]?.attrMap ?? {};
+  for (const [key, value] of Object.entries(editData)) {
+    ghostEl.setAttribute(attrMap[key] ?? key, value);
+  }
+}
+
+/**
  * Render the drawing layer: clear layerEl, then mirror every drawing element
  * as a live SVG node with the layer's interaction cursor applied.
  */
@@ -484,6 +499,7 @@ export function makeLayerAPI(ydoc, yDrawing) {
     applyResize:     (yEl, x, y, w, h) => applyResize(ydoc, yEl, x, y, w, h),
     applyTtState:    (state)         => applyTtState(ydoc, yDrawing, state),
     edit:            (yEl, editData) => edit(ydoc, yEl, editData),
+    previewEdit,
     listData:        ()              => drawingsData(yDrawing),
     render:          (layerEl)       => render(yDrawing, layerEl),
   };

--- a/src/overlay.js
+++ b/src/overlay.js
@@ -590,30 +590,39 @@ export function endResizeGhost(elId) {
   render();
 }
 
-// ── Attribute ghosts ─────────────────────────────────────────────────────────
-// Live preview for a plain attribute tweak (e.g. a drawing shape's
-// stroke-width) that changes no geometry — same rationale as the resize
-// ghost above: the real element can be wiped out mid-gesture by any peer's
-// Yjs transaction (a full toys/drawing-layer rebuild), so the live preview
-// lives on a detached clone that survives render() calls, not the real
-// element. Simpler than the resize ghost's two-copy scheme: since nothing
-// moves or resizes, the dim placeholder and the bright ghost sit at the
-// exact same footprint as the real element, so the ghost (drawn after, at
-// z-top) fully occludes the placeholder AND the real element beneath it —
-// net visual effect is just the live preview, no double-vision, with no
+// ── Edit-preview ghosts ──────────────────────────────────────────────────────
+// Live preview for an in-progress Edit-panel gesture (e.g. a drawing
+// shape's stroke-width, or a boun_pos position-set's snap-point grid) that
+// changes no geometry — same rationale as the resize ghost above: the real
+// element can be wiped out mid-gesture by any peer's Yjs transaction (a
+// full toys/drawing/boun_pos-layer rebuild), so the live preview lives on
+// a detached clone that survives render() calls, not the real element.
+// Simpler than the resize ghost's two-copy scheme: since nothing moves or
+// resizes, the dim placeholder and the bright ghost sit at the exact same
+// footprint as the real element, so the ghost (drawn after, at z-top)
+// fully occludes the placeholder AND the real element beneath it — net
+// visual effect is just the live preview, no double-vision, with no
 // separate hide/show step needed for the real element.
+//
+// overlay.js itself has no idea what's being previewed — updateGhost just
+// hands the raw ghost DOM node to a caller-supplied mutator. It's App's
+// previewEdit (app.js) that asks the relevant layer module (boun_pos.js,
+// drawing.js, toys.js) how to apply an editData object to a ghost of its
+// own element type — only that module knows its own DOM shape (e.g. only
+// boun_pos.js knows a position-set's circles are derived from spacing and
+// need regenerating, not just re-attributed).
 // Map<elId, { placeholderEl, ghostEl }>
-const _attrGhosts = new Map();
+const _ghosts = new Map();
 
 /**
- * Begin a local attribute preview. Creates a dim placeholder at the
- * element's committed state (mirrors startResizeGhost) and a live clone to
- * preview attribute changes into. No-op if a ghost for this elId already
- * exists, or if the element can't be found — safe to call on every tick of
- * a gesture, not just the first (see App.previewEdit).
+ * Begin a local edit preview. Creates a dim placeholder at the element's
+ * committed state (mirrors startResizeGhost) and a live clone to preview
+ * changes into. No-op if a ghost for this elId already exists, or if the
+ * element can't be found — safe to call on every tick of a gesture, not
+ * just the first (see App.previewEdit).
  */
-export function startAttrGhost(elId) {
-  if (!_layerEl || _attrGhosts.has(elId)) return;
+export function startGhost(elId) {
+  if (!_layerEl || _ghosts.has(elId)) return;
   const liveEl = _svgEl?.querySelector(`[data-id="${elId}"]`);
   if (!liveEl) return;
 
@@ -624,63 +633,36 @@ export function startAttrGhost(elId) {
   const ghostEl = liveEl.cloneNode(true);
   ghostEl.removeAttribute('id');
 
-  _attrGhosts.set(elId, { placeholderEl, ghostEl });
+  _ghosts.set(elId, { placeholderEl, ghostEl });
   render();
 }
 
 /**
- * Set one attribute on the live ghost clone. attr is the real SVG
- * attribute name (already resolved from any schema-key alias by the
- * caller — see App.previewEdit) — this function is deliberately generic
- * over what attribute or element type it's touching, the same way
- * updateResizeGhost's rect/circle/svg branches are the only place that
- * needs to know shape-specific structure.
+ * Hand the live ghost clone's DOM node to `mutate` so the caller can apply
+ * whatever change it represents. Deliberately generic — overlay.js doesn't
+ * know or care whether that means setting one attribute or rebuilding a
+ * whole subtree of children; that knowledge lives with whoever passes
+ * `mutate` in (see App.previewEdit, which delegates to the element's own
+ * layer module). No-op if no ghost was started for this id.
  */
-export function updateAttrGhost(elId, attr, value) {
-  const entry = _attrGhosts.get(elId);
+export function updateGhost(elId, mutate) {
+  const entry = _ghosts.get(elId);
   if (!entry) return;
-  entry.ghostEl.setAttribute(attr, value);
+  mutate(entry.ghostEl);
 }
 
 /**
- * Rebuild the ghost clone's <circle> children to match a freshly computed
- * position-set grid (see boun_pos.js's computeGridPositions) — unlike a
- * plain attribute tweak, changing spacing/snapRadius changes how many
- * snap points there are, so this replaces the whole set rather than
- * mutating cx/cy/r on however many happened to exist before. Reuses the
- * first existing circle as a template (preserving its fill — the
- * snap-point gradient — and any other authored attributes) for every new
- * position; falls back to a bare circle only if the ghost started with
- * none at all.
- */
-export function updatePosSetGhost(elId, circles, r) {
-  const entry = _attrGhosts.get(elId);
-  if (!entry) return;
-  const existing = [...entry.ghostEl.querySelectorAll(':scope > circle')];
-  const template = existing[0] ?? null;
-  for (const c of existing) c.remove();
-  for (const { cx, cy } of circles) {
-    const circle = template ? template.cloneNode(true) : el('circle', {});
-    circle.setAttribute('cx', Math.round(cx));
-    circle.setAttribute('cy', Math.round(cy));
-    circle.setAttribute('r',  Math.round(r));
-    entry.ghostEl.appendChild(circle);
-  }
-}
-
-/**
- * End a local attribute preview (commit or cancel). Removes the
+ * End a local edit preview (commit or cancel). Removes the
  * ghost/placeholder and triggers a render so the (now-committed, or
  * reverted) real element takes over. Same ordering requirement as
- * endResizeGhost: call this AFTER a real attribute change lands, not
- * before.
+ * endResizeGhost: call this AFTER a real change lands, not before.
  */
-export function endAttrGhost(elId) {
-  const entry = _attrGhosts.get(elId);
+export function endGhost(elId) {
+  const entry = _ghosts.get(elId);
   if (!entry) return;
   entry.placeholderEl.remove();
   entry.ghostEl.remove();
-  _attrGhosts.delete(elId);
+  _ghosts.delete(elId);
   render();
 }
 
@@ -767,7 +749,7 @@ export function render() {
   for (const entry of _resizeGhosts.values()) {
     _layerEl.appendChild(entry.placeholderEl);
   }
-  for (const entry of _attrGhosts.values()) {
+  for (const entry of _ghosts.values()) {
     _layerEl.appendChild(entry.placeholderEl);
   }
   for (const [elId] of _remoteDrags) {
@@ -862,8 +844,8 @@ export function render() {
     _layerEl.appendChild(entry.ringEl);
   }
 
-  // ── Local attribute-preview ghosts — z-top ─────────────────────────────
-  for (const entry of _attrGhosts.values()) {
+  // ── Local edit-preview ghosts — z-top ──────────────────────────────────
+  for (const entry of _ghosts.values()) {
     _layerEl.appendChild(entry.ghostEl);
   }
 

--- a/src/overlay.js
+++ b/src/overlay.js
@@ -643,6 +643,32 @@ export function updateAttrGhost(elId, attr, value) {
 }
 
 /**
+ * Rebuild the ghost clone's <circle> children to match a freshly computed
+ * position-set grid (see boun_pos.js's computeGridPositions) — unlike a
+ * plain attribute tweak, changing spacing/snapRadius changes how many
+ * snap points there are, so this replaces the whole set rather than
+ * mutating cx/cy/r on however many happened to exist before. Reuses the
+ * first existing circle as a template (preserving its fill — the
+ * snap-point gradient — and any other authored attributes) for every new
+ * position; falls back to a bare circle only if the ghost started with
+ * none at all.
+ */
+export function updatePosSetGhost(elId, circles, r) {
+  const entry = _attrGhosts.get(elId);
+  if (!entry) return;
+  const existing = [...entry.ghostEl.querySelectorAll(':scope > circle')];
+  const template = existing[0] ?? null;
+  for (const c of existing) c.remove();
+  for (const { cx, cy } of circles) {
+    const circle = template ? template.cloneNode(true) : el('circle', {});
+    circle.setAttribute('cx', Math.round(cx));
+    circle.setAttribute('cy', Math.round(cy));
+    circle.setAttribute('r',  Math.round(r));
+    entry.ghostEl.appendChild(circle);
+  }
+}
+
+/**
  * End a local attribute preview (commit or cancel). Removes the
  * ghost/placeholder and triggers a render so the (now-committed, or
  * reverted) real element takes over. Same ordering requirement as

--- a/src/overlay.js
+++ b/src/overlay.js
@@ -610,7 +610,7 @@ const _attrGhosts = new Map();
  * element's committed state (mirrors startResizeGhost) and a live clone to
  * preview attribute changes into. No-op if a ghost for this elId already
  * exists, or if the element can't be found — safe to call on every tick of
- * a gesture, not just the first (see App.previewField).
+ * a gesture, not just the first (see App.previewEdit).
  */
 export function startAttrGhost(elId) {
   if (!_layerEl || _attrGhosts.has(elId)) return;
@@ -631,7 +631,7 @@ export function startAttrGhost(elId) {
 /**
  * Set one attribute on the live ghost clone. attr is the real SVG
  * attribute name (already resolved from any schema-key alias by the
- * caller — see App.previewField) — this function is deliberately generic
+ * caller — see App.previewEdit) — this function is deliberately generic
  * over what attribute or element type it's touching, the same way
  * updateResizeGhost's rect/circle/svg branches are the only place that
  * needs to know shape-specific structure.

--- a/src/overlay.js
+++ b/src/overlay.js
@@ -492,13 +492,7 @@ export function endDragPlaceholder(elId) {
 // real toy element can be wiped out mid-gesture by renderToysLayer()'s full
 // innerHTML rebuild (fired by ANY peer's Yjs transaction, not just this
 // client's own), so the live preview lives on a detached clone that
-// survives render() calls, not the real element. A <use> placeholder alone
-// (as the move-ghost uses) can't show the resize itself — <use>'s
-// width/height override only applies when the referenced element is an
-// <svg> or <symbol>, and the href here targets the toy's outer <g>
-// wrapper — so instead the ghost is a real cloned copy of the toy's DOM,
-// with its own embedded <svg> directly
-// mutated to the current preview size on every updateResizeGhost() call.
+// survives render() calls, not the real element.
 // Map<elId, { placeholderEl, ghostEl, ringEl }>
 const _resizeGhosts = new Map();
 
@@ -591,35 +585,19 @@ export function endResizeGhost(elId) {
 }
 
 // ── Edit-preview ghosts ──────────────────────────────────────────────────────
-// Live preview for an in-progress Edit-panel gesture (e.g. a drawing
-// shape's stroke-width, or a boun_pos position-set's snap-point grid) that
-// changes no geometry — same rationale as the resize ghost above: the real
+// Live preview for an in-progress Edit-panel gesture
+//
+// Changes no geometry — same rationale as the resize ghost above: the real
 // element can be wiped out mid-gesture by any peer's Yjs transaction (a
 // full toys/drawing/boun_pos-layer rebuild), so the live preview lives on
 // a detached clone that survives render() calls, not the real element.
-// Simpler than the resize ghost's two-copy scheme: since nothing moves or
-// resizes, the dim placeholder and the bright ghost sit at the exact same
-// footprint as the real element, so the ghost (drawn after, at z-top)
-// fully occludes the placeholder AND the real element beneath it — net
-// visual effect is just the live preview, no double-vision, with no
-// separate hide/show step needed for the real element.
 //
-// overlay.js itself has no idea what's being previewed — updateGhost just
-// hands the raw ghost DOM node to a caller-supplied mutator. It's App's
-// previewEdit (app.js) that asks the relevant layer module (boun_pos.js,
-// drawing.js, toys.js) how to apply an editData object to a ghost of its
-// own element type — only that module knows its own DOM shape (e.g. only
-// boun_pos.js knows a position-set's circles are derived from spacing and
-// need regenerating, not just re-attributed).
 // Map<elId, { placeholderEl, ghostEl }>
 const _ghosts = new Map();
 
 /**
  * Begin a local edit preview. Creates a dim placeholder at the element's
- * committed state (mirrors startResizeGhost) and a live clone to preview
- * changes into. No-op if a ghost for this elId already exists, or if the
- * element can't be found — safe to call on every tick of a gesture, not
- * just the first (see App.previewEdit).
+ * committed state and a live clone to preview changes into.
  */
 export function startGhost(elId) {
   if (!_layerEl || _ghosts.has(elId)) return;
@@ -641,9 +619,7 @@ export function startGhost(elId) {
  * Hand the live ghost clone's DOM node to `mutate` so the caller can apply
  * whatever change it represents. Deliberately generic — overlay.js doesn't
  * know or care whether that means setting one attribute or rebuilding a
- * whole subtree of children; that knowledge lives with whoever passes
- * `mutate` in (see App.previewEdit, which delegates to the element's own
- * layer module). No-op if no ghost was started for this id.
+ * whole subtree of children
  */
 export function updateGhost(elId, mutate) {
   const entry = _ghosts.get(elId);
@@ -676,8 +652,8 @@ let _dropTargetId = null;
 /**
  * The elId currently showing the action-mode affordance (kebab + * icon
  * squares), or null. Set by App whenever the sole local selection supports
- * the 'action' select mode (see LayerAPI.selectModes) — currently all
- * toys. A single id, like resize mode — the affordance only makes sense
+ * the 'action' select mode; currently all toys.
+ * A single id, like resize mode — the affordance only makes sense
  * for an exclusive single selection.
  */
 let _actionAffordanceId = null;

--- a/src/overlay.js
+++ b/src/overlay.js
@@ -590,6 +590,74 @@ export function endResizeGhost(elId) {
   render();
 }
 
+// ── Attribute ghosts ─────────────────────────────────────────────────────────
+// Live preview for a plain attribute tweak (e.g. a drawing shape's
+// stroke-width) that changes no geometry — same rationale as the resize
+// ghost above: the real element can be wiped out mid-gesture by any peer's
+// Yjs transaction (a full toys/drawing-layer rebuild), so the live preview
+// lives on a detached clone that survives render() calls, not the real
+// element. Simpler than the resize ghost's two-copy scheme: since nothing
+// moves or resizes, the dim placeholder and the bright ghost sit at the
+// exact same footprint as the real element, so the ghost (drawn after, at
+// z-top) fully occludes the placeholder AND the real element beneath it —
+// net visual effect is just the live preview, no double-vision, with no
+// separate hide/show step needed for the real element.
+// Map<elId, { placeholderEl, ghostEl }>
+const _attrGhosts = new Map();
+
+/**
+ * Begin a local attribute preview. Creates a dim placeholder at the
+ * element's committed state (mirrors startResizeGhost) and a live clone to
+ * preview attribute changes into. No-op if a ghost for this elId already
+ * exists, or if the element can't be found — safe to call on every tick of
+ * a gesture, not just the first (see App.previewField).
+ */
+export function startAttrGhost(elId) {
+  if (!_layerEl || _attrGhosts.has(elId)) return;
+  const liveEl = _svgEl?.querySelector(`[data-id="${elId}"]`);
+  if (!liveEl) return;
+
+  const placeholderEl = el('use', {});
+  placeholderEl.setAttribute('href', `#${elId}`);
+  placeholderEl.setAttribute('filter', 'url(#drag-placeholder-filter)');
+
+  const ghostEl = liveEl.cloneNode(true);
+  ghostEl.removeAttribute('id');
+
+  _attrGhosts.set(elId, { placeholderEl, ghostEl });
+  render();
+}
+
+/**
+ * Set one attribute on the live ghost clone. attr is the real SVG
+ * attribute name (already resolved from any schema-key alias by the
+ * caller — see App.previewField) — this function is deliberately generic
+ * over what attribute or element type it's touching, the same way
+ * updateResizeGhost's rect/circle/svg branches are the only place that
+ * needs to know shape-specific structure.
+ */
+export function updateAttrGhost(elId, attr, value) {
+  const entry = _attrGhosts.get(elId);
+  if (!entry) return;
+  entry.ghostEl.setAttribute(attr, value);
+}
+
+/**
+ * End a local attribute preview (commit or cancel). Removes the
+ * ghost/placeholder and triggers a render so the (now-committed, or
+ * reverted) real element takes over. Same ordering requirement as
+ * endResizeGhost: call this AFTER a real attribute change lands, not
+ * before.
+ */
+export function endAttrGhost(elId) {
+  const entry = _attrGhosts.get(elId);
+  if (!entry) return;
+  entry.placeholderEl.remove();
+  entry.ghostEl.remove();
+  _attrGhosts.delete(elId);
+  render();
+}
+
 // ── Drop-target hover
 // The el id currently under a toy being dragged, or null. Set by
 // App.move() on every pointermove while dragging a toy (re-hit-tested each
@@ -671,6 +739,9 @@ export function render() {
     _layerEl.appendChild(entry.placeholderEl);
   }
   for (const entry of _resizeGhosts.values()) {
+    _layerEl.appendChild(entry.placeholderEl);
+  }
+  for (const entry of _attrGhosts.values()) {
     _layerEl.appendChild(entry.placeholderEl);
   }
   for (const [elId] of _remoteDrags) {
@@ -763,6 +834,11 @@ export function render() {
   for (const entry of _resizeGhosts.values()) {
     _layerEl.appendChild(entry.ghostEl);
     _layerEl.appendChild(entry.ringEl);
+  }
+
+  // ── Local attribute-preview ghosts — z-top ─────────────────────────────
+  for (const entry of _attrGhosts.values()) {
+    _layerEl.appendChild(entry.ghostEl);
   }
 
   renderBowstringCharge(scale);

--- a/src/toys.js
+++ b/src/toys.js
@@ -1479,6 +1479,19 @@ export function editDom(toyEl, editData) {
   }
 }
 
+/**
+ * Preview an edit on a detached ghost clone (see overlay.js's ghost
+ * system, used via App.previewEdit) — mutates ghostEl's own attributes
+ * directly, never touches Yjs. Unlike drawing.js's shapes, toy editData
+ * keys map straight onto DOM attributes with no aliasing, so this is a
+ * plain attribute-per-key loop.
+ */
+export function previewEdit(ghostEl, editData) {
+  for (const [key, value] of Object.entries(editData)) {
+    ghostEl.setAttribute(key, value)
+  }
+}
+
 // ── Toy behaviour contract ──────────────────────────────────────────────────
 //
 // A toy's <script> tags (hoisted out to the document's own `scripts`
@@ -2298,6 +2311,7 @@ export function makeLayerAPI(ydoc, getLayerEl, myId, tableId, isCreator = false)
     },
     applyResize:     (el, x, y, w, h) => gesture('resize', () => applyResizeDom(el, x, y, w, h)),
     edit:            (el, editData)  => gesture('edit',   () => editDom(el, editData)),
+    previewEdit,
     listData:        ()              => toysDataDom(layer()),
     render:          (layerEl)       => projectLayer(ydoc, layerEl, { tableId, authorId: myId, isCreator }),
     receive:         (layerEl, opId) => receiveToyOp(ydoc, layerEl, opId, tableId),

--- a/src/ui.js
+++ b/src/ui.js
@@ -565,11 +565,12 @@ export function wireColorPickers(container) {
 // tears the element down mid-drag, killing the browser's native slider
 // tracking on it. So 'edit' mode instead treats the two range-ticked
 // events differently: 'range-changed' (every tick) only drives a local
-// preview via App.previewField — a detached ghost clone on the Overlay
-// layer, no Yjs write, so #panelBody is never touched mid-drag — and only
-// 'range-committed' (fires once, when the gesture actually ends) calls
-// App.commitFieldPreview, which does the real Yjs write and only then
-// lets #panelBody re-render.
+// preview via App.previewEdit(id, editData) — a detached ghost clone on
+// the Overlay layer, no Yjs write, so #panelBody is never touched mid-drag
+// — and only 'range-committed' (fires once, when the gesture actually
+// ends) calls the real App.commitEdit(id, editData), same as any other
+// Edit-panel field, which does the Yjs write and (as part of committing)
+// clears the preview ghost.
 export function wireRangeTicked(container) {
   if (!container) return;
   container.querySelectorAll('range-ticked[data-rt-wire]').forEach(el => {
@@ -578,8 +579,8 @@ export function wireRangeTicked(container) {
     const key    = el.dataset.rtKey;
 
     if (mode === 'edit') {
-      el.addEventListener('range-changed',   (e) => App.previewField(target, key, e.detail.value));
-      el.addEventListener('range-committed', (e) => App.commitFieldPreview(target, key, e.detail.value));
+      el.addEventListener('range-changed',   (e) => App.previewEdit(target, { [key]: e.detail.value }));
+      el.addEventListener('range-committed', (e) => App.commitEdit(target, { [key]: e.detail.value }));
       return;
     }
 

--- a/src/ui.js
+++ b/src/ui.js
@@ -550,13 +550,26 @@ export function wireColorPickers(container) {
 // renderSchemaField and checkpointFrequencyHTML emit <range-ticked>
 // elements with no event listeners (both are pure string renderers).
 // After any innerHTML assignment that may contain `[data-rt-wire]`
-// elements, call wireRangeTicked(container) to attach 'range-changed'
-// listeners. No re-render call here on purpose: <range-ticked> keeps its
-// own tick labels in sync internally (see component/range_ticked.js), so
-// there's nothing left for a caller-side refresh to do — and calling one
-// on every drag tick would replace the live <range-ticked> element out
-// from under the user's own drag, the exact bug this component exists to
-// avoid (see RANGE_TICKED_README.md's "why value gets a cheap update path").
+// elements, call wireRangeTicked(container) to attach listeners.
+//
+// 'add'/'addQuick'/'checkpoint' fields never write anywhere that triggers
+// a re-render (App.setToolParam and onCheckpointFrequencyInput both just
+// mutate local state / patch one label), so they wire 'range-changed'
+// (fires on every drag tick) straight through — there's nothing to
+// interrupt.
+//
+// 'edit' fields are different: App.commitEdit writes to the live Yjs doc,
+// and that synchronously triggers UI.refreshFromDoc(), which replaces
+// #panelBody's whole innerHTML — including the very <range-ticked> the
+// user has their mouse on. Calling that on every 'range-changed' tick
+// tears the element down mid-drag, killing the browser's native slider
+// tracking on it. So 'edit' mode instead treats the two range-ticked
+// events differently: 'range-changed' (every tick) only drives a local
+// preview via App.previewField — a detached ghost clone on the Overlay
+// layer, no Yjs write, so #panelBody is never touched mid-drag — and only
+// 'range-committed' (fires once, when the gesture actually ends) calls
+// App.commitFieldPreview, which does the real Yjs write and only then
+// lets #panelBody re-render.
 export function wireRangeTicked(container) {
   if (!container) return;
   container.querySelectorAll('range-ticked[data-rt-wire]').forEach(el => {
@@ -564,11 +577,15 @@ export function wireRangeTicked(container) {
     const target = el.dataset.rtTarget; // element id (edit) or tool name (add/addQuick)
     const key    = el.dataset.rtKey;
 
+    if (mode === 'edit') {
+      el.addEventListener('range-changed',   (e) => App.previewField(target, key, e.detail.value));
+      el.addEventListener('range-committed', (e) => App.commitFieldPreview(target, key, e.detail.value));
+      return;
+    }
+
     el.addEventListener('range-changed', (e) => {
       const value = e.detail.value;
-      if (mode === 'edit') {
-        App.commitEdit(target, { [key]: value });
-      } else if (mode === 'checkpoint') {
+      if (mode === 'checkpoint') {
         onCheckpointFrequencyInput(value);
       } else {
         App.setToolParam(target, key, value);

--- a/tests/unit/attr-ghost.test.js
+++ b/tests/unit/attr-ghost.test.js
@@ -1,13 +1,20 @@
 /**
  * tests/unit/attr-ghost.test.js
  *
- * overlay.js's attribute-preview ghost (startAttrGhost/updateAttrGhost/
- * endAttrGhost) — the mechanism behind App.previewEdit(id, editData)
- * (app.js), which lets an Edit-panel field (e.g. a <range-ticked>
- * stroke-width slider) show a live preview on the canvas without writing
- * to Yjs on every drag tick. Same rationale, and same harness pattern
- * (real overlay.js + jsdom, no App boot), as drop-target-hover.test.js /
+ * overlay.js's generic edit-preview ghost (startGhost/updateGhost/
+ * endGhost) — the mechanism behind App.previewEdit(id, editData) (app.js),
+ * which lets an Edit-panel field (e.g. a <range-ticked> stroke-width
+ * slider) show a live preview on the canvas without writing to Yjs on
+ * every drag tick. Same rationale, and same harness pattern (real
+ * overlay.js + jsdom, no App boot), as drop-target-hover.test.js /
  * resize.test.js.
+ *
+ * overlay.js itself has no idea what's being previewed — updateGhost just
+ * hands the ghost DOM node to a caller-supplied mutator, so these tests
+ * only exercise the generic clone/mutate/teardown lifecycle. The
+ * structure-aware mutations (e.g. a boun_pos position-set's circles being
+ * regenerated from spacing) are each layer module's own business — see
+ * boun_pos.test.js's `previewEdit` describe block for that coverage.
  *
  * app.js's previewEdit/commitEdit/cancelEdit themselves are untested here
  * by convention — see this project's established pattern of not
@@ -19,7 +26,7 @@
 // @vitest-environment jsdom
 import { describe, test, expect, beforeEach } from 'vitest'
 import {
-  startAttrGhost, updateAttrGhost, endAttrGhost, updatePosSetGhost,
+  startGhost, updateGhost, endGhost,
   init as overlayInit,
 } from '../../src/overlay.js'
 
@@ -62,41 +69,16 @@ function placeRect(id, attrs = {}) {
   return rect
 }
 
-// Mirrors a real boun_pos position-set: a <g data-id> with <path>, <text>,
-// and N <circle fill="url(#...)"> children (see boun_pos.js's
-// _positionSetToSVGEl) — the circle's fill is what updatePosSetGhost's
-// template-clone approach exists to preserve.
-function placePosSet(id, circleCount = 4, r = 10) {
-  const g = document.createElementNS(SVG_NS, 'g')
-  g.setAttribute('data-id', id)
-  g.setAttribute('id', id)
-  g.setAttribute('data-module', 'boun_pos')
-  g.setAttribute('data-bounpos-type', 'pos-set')
-  const path = document.createElementNS(SVG_NS, 'path')
-  path.setAttribute('d', 'M0,0 L200,0 L200,200 L0,200 Z')
-  g.appendChild(path)
-  for (let i = 0; i < circleCount; i++) {
-    const circle = document.createElementNS(SVG_NS, 'circle')
-    circle.setAttribute('cx', String(i * 50))
-    circle.setAttribute('cy', String(i * 50))
-    circle.setAttribute('r', String(r))
-    circle.setAttribute('fill', 'url(#snap-point-grad)')
-    g.appendChild(circle)
-  }
-  document.getElementById('drawing-layer').appendChild(g) // any layer works for this harness
-  return g
-}
-
 beforeEach(() => {
   makeOverlayDOM()
   overlayInit(makeOverlayApp(), document.getElementById('canvas'))
-  endAttrGhost('shape1') // _attrGhosts is module state; clear leftovers from a prior test
+  endGhost('shape1') // ghost state is module state; clear leftovers from a prior test
 })
 
-describe('startAttrGhost', () => {
+describe('startGhost', () => {
   test('clones the live element into #overlay-layer, stripping its id', () => {
     placeRect('shape1')
-    startAttrGhost('shape1')
+    startGhost('shape1')
 
     const ghosts = [...document.querySelectorAll('#overlay-layer rect')]
     expect(ghosts).toHaveLength(1)
@@ -106,7 +88,7 @@ describe('startAttrGhost', () => {
 
   test('also adds a dim placeholder <use> referencing the real element', () => {
     placeRect('shape1')
-    startAttrGhost('shape1')
+    startGhost('shape1')
 
     const use = document.querySelector('#overlay-layer use')
     expect(use).not.toBeNull()
@@ -115,119 +97,67 @@ describe('startAttrGhost', () => {
   })
 
   test('is a no-op if the element cannot be found', () => {
-    startAttrGhost('does-not-exist')
+    startGhost('does-not-exist')
     expect(document.querySelectorAll('#overlay-layer *')).toHaveLength(0)
   })
 
   test('is idempotent — a second call for the same id does not add a second ghost', () => {
     placeRect('shape1')
-    startAttrGhost('shape1')
-    startAttrGhost('shape1')
+    startGhost('shape1')
+    startGhost('shape1')
     expect(document.querySelectorAll('#overlay-layer rect')).toHaveLength(1)
   })
 })
 
-describe('updateAttrGhost', () => {
-  test('sets the attribute on the ghost clone only — the real element is untouched', () => {
+describe('updateGhost', () => {
+  test('hands the ghost clone to the mutator — the real element is untouched', () => {
     placeRect('shape1')
-    startAttrGhost('shape1')
+    startGhost('shape1')
 
-    updateAttrGhost('shape1', 'stroke-width', 6)
+    updateGhost('shape1', (ghostEl) => ghostEl.setAttribute('stroke-width', 6))
 
     const ghost = document.querySelector('#overlay-layer rect')
     expect(ghost.getAttribute('stroke-width')).toBe('6')
     expect(document.getElementById('shape1').getAttribute('stroke-width')).toBe('1.5') // real element, unchanged
   })
 
-  test('is a no-op if no ghost was started for that id', () => {
+  test('is a no-op if no ghost was started for that id — the mutator is never called', () => {
     placeRect('shape1')
-    expect(() => updateAttrGhost('shape1', 'stroke-width', 6)).not.toThrow()
+    let called = false
+    expect(() => updateGhost('shape1', () => { called = true })).not.toThrow()
+    expect(called).toBe(false)
     expect(document.querySelectorAll('#overlay-layer *')).toHaveLength(0)
   })
 
   test('can be called many times in a row without re-adding DOM nodes (cheap per-tick update)', () => {
     placeRect('shape1')
-    startAttrGhost('shape1')
-    for (const v of [2, 3, 4, 5, 6]) updateAttrGhost('shape1', 'stroke-width', v)
+    startGhost('shape1')
+    for (const v of [2, 3, 4, 5, 6]) updateGhost('shape1', (ghostEl) => ghostEl.setAttribute('stroke-width', v))
     expect(document.querySelectorAll('#overlay-layer rect')).toHaveLength(1)
     expect(document.querySelector('#overlay-layer rect').getAttribute('stroke-width')).toBe('6')
   })
 })
 
-describe('endAttrGhost', () => {
+describe('endGhost', () => {
   test('removes both the ghost clone and the placeholder', () => {
     placeRect('shape1')
-    startAttrGhost('shape1')
-    updateAttrGhost('shape1', 'stroke-width', 6)
+    startGhost('shape1')
+    updateGhost('shape1', (ghostEl) => ghostEl.setAttribute('stroke-width', 6))
 
-    endAttrGhost('shape1')
+    endGhost('shape1')
 
     expect(document.querySelectorAll('#overlay-layer *')).toHaveLength(0)
   })
 
   test('is a no-op if no ghost is active for that id', () => {
-    expect(() => endAttrGhost('shape1')).not.toThrow()
+    expect(() => endGhost('shape1')).not.toThrow()
   })
 
-  test('a later startAttrGhost for the same id works again after ending — not permanently stuck', () => {
+  test('a later startGhost for the same id works again after ending — not permanently stuck', () => {
     placeRect('shape1')
-    startAttrGhost('shape1')
-    endAttrGhost('shape1')
-    startAttrGhost('shape1')
+    startGhost('shape1')
+    endGhost('shape1')
+    startGhost('shape1')
     expect(document.querySelectorAll('#overlay-layer rect')).toHaveLength(1)
-  })
-})
-
-describe('updatePosSetGhost', () => {
-  test('replaces the ghost’s circle children to match a new grid, preserving the fill from an existing circle', () => {
-    placePosSet('shape1', 4, 10)
-    startAttrGhost('shape1')
-
-    updatePosSetGhost('shape1', [{ cx: 0, cy: 0 }, { cx: 25, cy: 0 }, { cx: 0, cy: 25 }], 6)
-
-    const circles = [...document.querySelectorAll('#overlay-layer g[data-id="shape1"] > circle')]
-    expect(circles).toHaveLength(3) // count changed — a denser grid than the original 4
-    expect(circles.map(c => [c.getAttribute('cx'), c.getAttribute('cy'), c.getAttribute('r')]))
-      .toEqual([['0', '0', '6'], ['25', '0', '6'], ['0', '25', '6']])
-    // Template-cloned from an existing circle, so the gradient fill survives.
-    expect(circles.every(c => c.getAttribute('fill') === 'url(#snap-point-grad)')).toBe(true)
-  })
-
-  test('the <path> and other non-circle children are untouched', () => {
-    placePosSet('shape1', 4, 10)
-    startAttrGhost('shape1')
-
-    updatePosSetGhost('shape1', [{ cx: 0, cy: 0 }], 6)
-
-    const ghost = document.querySelector('#overlay-layer g[data-id="shape1"]')
-    expect(ghost.querySelector('path').getAttribute('d')).toBe('M0,0 L200,0 L200,200 L0,200 Z')
-  })
-
-  test('falls back to a bare circle (no fill) if the ghost started with zero circles', () => {
-    placePosSet('shape1', 0)
-    startAttrGhost('shape1')
-
-    updatePosSetGhost('shape1', [{ cx: 5, cy: 5 }], 3)
-
-    const circles = [...document.querySelectorAll('#overlay-layer g[data-id="shape1"] > circle')]
-    expect(circles).toHaveLength(1)
-    expect(circles[0].getAttribute('cx')).toBe('5')
-  })
-
-  test('is a no-op if no ghost was started for that id', () => {
-    placePosSet('shape1', 4)
-    expect(() => updatePosSetGhost('shape1', [{ cx: 0, cy: 0 }], 6)).not.toThrow()
-    expect(document.querySelectorAll('#overlay-layer *')).toHaveLength(0)
-  })
-
-  test('the real element’s circles are never touched — only the ghost clone', () => {
-    const real = placePosSet('shape1', 4, 10)
-    startAttrGhost('shape1')
-
-    updatePosSetGhost('shape1', [{ cx: 999, cy: 999 }], 50)
-
-    const realCircles = [...real.querySelectorAll(':scope > circle')]
-    expect(realCircles).toHaveLength(4)
-    expect(realCircles[0].getAttribute('cx')).toBe('0') // untouched
   })
 })

--- a/tests/unit/attr-ghost.test.js
+++ b/tests/unit/attr-ghost.test.js
@@ -19,7 +19,7 @@
 // @vitest-environment jsdom
 import { describe, test, expect, beforeEach } from 'vitest'
 import {
-  startAttrGhost, updateAttrGhost, endAttrGhost,
+  startAttrGhost, updateAttrGhost, endAttrGhost, updatePosSetGhost,
   init as overlayInit,
 } from '../../src/overlay.js'
 
@@ -60,6 +60,31 @@ function placeRect(id, attrs = {}) {
   for (const [k, v] of Object.entries(attrs)) rect.setAttribute(k, v)
   document.getElementById('drawing-layer').appendChild(rect)
   return rect
+}
+
+// Mirrors a real boun_pos position-set: a <g data-id> with <path>, <text>,
+// and N <circle fill="url(#...)"> children (see boun_pos.js's
+// _positionSetToSVGEl) — the circle's fill is what updatePosSetGhost's
+// template-clone approach exists to preserve.
+function placePosSet(id, circleCount = 4, r = 10) {
+  const g = document.createElementNS(SVG_NS, 'g')
+  g.setAttribute('data-id', id)
+  g.setAttribute('id', id)
+  g.setAttribute('data-module', 'boun_pos')
+  g.setAttribute('data-bounpos-type', 'pos-set')
+  const path = document.createElementNS(SVG_NS, 'path')
+  path.setAttribute('d', 'M0,0 L200,0 L200,200 L0,200 Z')
+  g.appendChild(path)
+  for (let i = 0; i < circleCount; i++) {
+    const circle = document.createElementNS(SVG_NS, 'circle')
+    circle.setAttribute('cx', String(i * 50))
+    circle.setAttribute('cy', String(i * 50))
+    circle.setAttribute('r', String(r))
+    circle.setAttribute('fill', 'url(#snap-point-grad)')
+    g.appendChild(circle)
+  }
+  document.getElementById('drawing-layer').appendChild(g) // any layer works for this harness
+  return g
 }
 
 beforeEach(() => {
@@ -150,5 +175,59 @@ describe('endAttrGhost', () => {
     endAttrGhost('shape1')
     startAttrGhost('shape1')
     expect(document.querySelectorAll('#overlay-layer rect')).toHaveLength(1)
+  })
+})
+
+describe('updatePosSetGhost', () => {
+  test('replaces the ghost’s circle children to match a new grid, preserving the fill from an existing circle', () => {
+    placePosSet('shape1', 4, 10)
+    startAttrGhost('shape1')
+
+    updatePosSetGhost('shape1', [{ cx: 0, cy: 0 }, { cx: 25, cy: 0 }, { cx: 0, cy: 25 }], 6)
+
+    const circles = [...document.querySelectorAll('#overlay-layer g[data-id="shape1"] > circle')]
+    expect(circles).toHaveLength(3) // count changed — a denser grid than the original 4
+    expect(circles.map(c => [c.getAttribute('cx'), c.getAttribute('cy'), c.getAttribute('r')]))
+      .toEqual([['0', '0', '6'], ['25', '0', '6'], ['0', '25', '6']])
+    // Template-cloned from an existing circle, so the gradient fill survives.
+    expect(circles.every(c => c.getAttribute('fill') === 'url(#snap-point-grad)')).toBe(true)
+  })
+
+  test('the <path> and other non-circle children are untouched', () => {
+    placePosSet('shape1', 4, 10)
+    startAttrGhost('shape1')
+
+    updatePosSetGhost('shape1', [{ cx: 0, cy: 0 }], 6)
+
+    const ghost = document.querySelector('#overlay-layer g[data-id="shape1"]')
+    expect(ghost.querySelector('path').getAttribute('d')).toBe('M0,0 L200,0 L200,200 L0,200 Z')
+  })
+
+  test('falls back to a bare circle (no fill) if the ghost started with zero circles', () => {
+    placePosSet('shape1', 0)
+    startAttrGhost('shape1')
+
+    updatePosSetGhost('shape1', [{ cx: 5, cy: 5 }], 3)
+
+    const circles = [...document.querySelectorAll('#overlay-layer g[data-id="shape1"] > circle')]
+    expect(circles).toHaveLength(1)
+    expect(circles[0].getAttribute('cx')).toBe('5')
+  })
+
+  test('is a no-op if no ghost was started for that id', () => {
+    placePosSet('shape1', 4)
+    expect(() => updatePosSetGhost('shape1', [{ cx: 0, cy: 0 }], 6)).not.toThrow()
+    expect(document.querySelectorAll('#overlay-layer *')).toHaveLength(0)
+  })
+
+  test('the real element’s circles are never touched — only the ghost clone', () => {
+    const real = placePosSet('shape1', 4, 10)
+    startAttrGhost('shape1')
+
+    updatePosSetGhost('shape1', [{ cx: 999, cy: 999 }], 50)
+
+    const realCircles = [...real.querySelectorAll(':scope > circle')]
+    expect(realCircles).toHaveLength(4)
+    expect(realCircles[0].getAttribute('cx')).toBe('0') // untouched
   })
 })

--- a/tests/unit/attr-ghost.test.js
+++ b/tests/unit/attr-ghost.test.js
@@ -2,18 +2,18 @@
  * tests/unit/attr-ghost.test.js
  *
  * overlay.js's attribute-preview ghost (startAttrGhost/updateAttrGhost/
- * endAttrGhost) — the mechanism behind App.previewField (app.js), which
- * lets an Edit-panel field (e.g. a <range-ticked> stroke-width slider)
- * show a live preview on the canvas without writing to Yjs on every drag
- * tick. Same rationale, and same harness pattern (real overlay.js +
- * jsdom, no App boot), as drop-target-hover.test.js / resize.test.js.
+ * endAttrGhost) — the mechanism behind App.previewEdit(id, editData)
+ * (app.js), which lets an Edit-panel field (e.g. a <range-ticked>
+ * stroke-width slider) show a live preview on the canvas without writing
+ * to Yjs on every drag tick. Same rationale, and same harness pattern
+ * (real overlay.js + jsdom, no App boot), as drop-target-hover.test.js /
+ * resize.test.js.
  *
- * app.js's previewField/commitFieldPreview/cancelFieldPreview themselves
- * are untested here by convention — see this project's established
- * pattern of not importing app.js in unit tests (e.g.
- * toy-position-snap.test.js's header) and instead testing the primitives
- * it orchestrates. Real end-to-end drag behavior is verified separately
- * in a browser.
+ * app.js's previewEdit/commitEdit/cancelEdit themselves are untested here
+ * by convention — see this project's established pattern of not
+ * importing app.js in unit tests (e.g. toy-position-snap.test.js's
+ * header) and instead testing the primitives it orchestrates. Real
+ * end-to-end drag behavior is verified separately in a browser.
  */
 
 // @vitest-environment jsdom

--- a/tests/unit/attr-ghost.test.js
+++ b/tests/unit/attr-ghost.test.js
@@ -1,0 +1,154 @@
+/**
+ * tests/unit/attr-ghost.test.js
+ *
+ * overlay.js's attribute-preview ghost (startAttrGhost/updateAttrGhost/
+ * endAttrGhost) — the mechanism behind App.previewField (app.js), which
+ * lets an Edit-panel field (e.g. a <range-ticked> stroke-width slider)
+ * show a live preview on the canvas without writing to Yjs on every drag
+ * tick. Same rationale, and same harness pattern (real overlay.js +
+ * jsdom, no App boot), as drop-target-hover.test.js / resize.test.js.
+ *
+ * app.js's previewField/commitFieldPreview/cancelFieldPreview themselves
+ * are untested here by convention — see this project's established
+ * pattern of not importing app.js in unit tests (e.g.
+ * toy-position-snap.test.js's header) and instead testing the primitives
+ * it orchestrates. Real end-to-end drag behavior is verified separately
+ * in a browser.
+ */
+
+// @vitest-environment jsdom
+import { describe, test, expect, beforeEach } from 'vitest'
+import {
+  startAttrGhost, updateAttrGhost, endAttrGhost,
+  init as overlayInit,
+} from '../../src/overlay.js'
+
+const SVG_NS = 'http://www.w3.org/2000/svg'
+
+function makeOverlayDOM() {
+  document.body.innerHTML = `
+    <svg id="canvas">
+      <defs>
+        <linearGradient id="local-sel-grad" x1="0" y1="0.5" x2="1" y2="0.5">
+          <stop id="local-sel-grad-stop0" offset="0%"   stop-color="#5a7ea8"></stop>
+          <stop id="local-sel-grad-stop1" offset="100%" stop-color="#3a5e88"></stop>
+        </linearGradient>
+      </defs>
+      <g id="drawing-layer"></g>
+      <g id="overlay-layer"></g>
+    </svg>
+  `
+}
+
+function makeOverlayApp() {
+  return {
+    getMyColor:    () => '#5a7ea8',
+    getMyGradient: () => ({ c1: '#5a7ea8', c2: '#3a5e88', angle: 45 }),
+    getViewScale:  () => 1,
+    getBBox:       () => null,
+  }
+}
+
+// Mirrors a real drawing-layer rect: data-id directly on the shape, no
+// wrapper (see drawing.js's _toSVGEl) — unlike toys, which wrap in <g>.
+function placeRect(id, attrs = {}) {
+  const rect = document.createElementNS(SVG_NS, 'rect')
+  rect.setAttribute('data-id', id)
+  rect.setAttribute('id', id)
+  rect.setAttribute('data-module', 'drawing')
+  rect.setAttribute('stroke-width', '1.5')
+  for (const [k, v] of Object.entries(attrs)) rect.setAttribute(k, v)
+  document.getElementById('drawing-layer').appendChild(rect)
+  return rect
+}
+
+beforeEach(() => {
+  makeOverlayDOM()
+  overlayInit(makeOverlayApp(), document.getElementById('canvas'))
+  endAttrGhost('shape1') // _attrGhosts is module state; clear leftovers from a prior test
+})
+
+describe('startAttrGhost', () => {
+  test('clones the live element into #overlay-layer, stripping its id', () => {
+    placeRect('shape1')
+    startAttrGhost('shape1')
+
+    const ghosts = [...document.querySelectorAll('#overlay-layer rect')]
+    expect(ghosts).toHaveLength(1)
+    expect(ghosts[0].hasAttribute('id')).toBe(false)
+    expect(ghosts[0]).not.toBe(document.getElementById('shape1')) // a clone, not the real node
+  })
+
+  test('also adds a dim placeholder <use> referencing the real element', () => {
+    placeRect('shape1')
+    startAttrGhost('shape1')
+
+    const use = document.querySelector('#overlay-layer use')
+    expect(use).not.toBeNull()
+    expect(use.getAttribute('href')).toBe('#shape1')
+    expect(use.getAttribute('filter')).toBe('url(#drag-placeholder-filter)')
+  })
+
+  test('is a no-op if the element cannot be found', () => {
+    startAttrGhost('does-not-exist')
+    expect(document.querySelectorAll('#overlay-layer *')).toHaveLength(0)
+  })
+
+  test('is idempotent — a second call for the same id does not add a second ghost', () => {
+    placeRect('shape1')
+    startAttrGhost('shape1')
+    startAttrGhost('shape1')
+    expect(document.querySelectorAll('#overlay-layer rect')).toHaveLength(1)
+  })
+})
+
+describe('updateAttrGhost', () => {
+  test('sets the attribute on the ghost clone only — the real element is untouched', () => {
+    placeRect('shape1')
+    startAttrGhost('shape1')
+
+    updateAttrGhost('shape1', 'stroke-width', 6)
+
+    const ghost = document.querySelector('#overlay-layer rect')
+    expect(ghost.getAttribute('stroke-width')).toBe('6')
+    expect(document.getElementById('shape1').getAttribute('stroke-width')).toBe('1.5') // real element, unchanged
+  })
+
+  test('is a no-op if no ghost was started for that id', () => {
+    placeRect('shape1')
+    expect(() => updateAttrGhost('shape1', 'stroke-width', 6)).not.toThrow()
+    expect(document.querySelectorAll('#overlay-layer *')).toHaveLength(0)
+  })
+
+  test('can be called many times in a row without re-adding DOM nodes (cheap per-tick update)', () => {
+    placeRect('shape1')
+    startAttrGhost('shape1')
+    for (const v of [2, 3, 4, 5, 6]) updateAttrGhost('shape1', 'stroke-width', v)
+    expect(document.querySelectorAll('#overlay-layer rect')).toHaveLength(1)
+    expect(document.querySelector('#overlay-layer rect').getAttribute('stroke-width')).toBe('6')
+  })
+})
+
+describe('endAttrGhost', () => {
+  test('removes both the ghost clone and the placeholder', () => {
+    placeRect('shape1')
+    startAttrGhost('shape1')
+    updateAttrGhost('shape1', 'stroke-width', 6)
+
+    endAttrGhost('shape1')
+
+    expect(document.querySelectorAll('#overlay-layer *')).toHaveLength(0)
+  })
+
+  test('is a no-op if no ghost is active for that id', () => {
+    expect(() => endAttrGhost('shape1')).not.toThrow()
+  })
+
+  test('a later startAttrGhost for the same id works again after ending — not permanently stuck', () => {
+    placeRect('shape1')
+    startAttrGhost('shape1')
+    endAttrGhost('shape1')
+    startAttrGhost('shape1')
+    expect(document.querySelectorAll('#overlay-layer rect')).toHaveLength(1)
+  })
+})

--- a/tests/unit/boun_pos.test.js
+++ b/tests/unit/boun_pos.test.js
@@ -165,7 +165,7 @@ describe('gridFillExtent', () => {
 describe('computeGridPositions', () => {
   // The same math rebuildPositionSetGrid uses to actually commit a
   // resize (see editBounPos/editEl below) — exposed separately so a live
-  // preview (overlay.js's updatePosSetGhost / app.js's previewField) can
+  // preview (overlay.js's updatePosSetGhost / app.js's previewEdit) can
   // compute the identical result without touching Yjs.
   test('circles match gridFillExtent for the same inputs', () => {
     const extent = { x: 0, y: 0, w: 200, h: 200 };

--- a/tests/unit/boun_pos.test.js
+++ b/tests/unit/boun_pos.test.js
@@ -14,7 +14,7 @@ import {
   // Geometry
   rectToPath, pathToRect,
   // Grid math
-  generateSquareGrid, generateHexGrid, gridFillExtent, computeMaxSnapRadius,
+  generateSquareGrid, generateHexGrid, gridFillExtent, computeMaxSnapRadius, computeGridPositions,
   // CRDT
   addBoundary, addPositionSet, createPositionSetElement, findEl, deleteEl, editBounPos, applyMoveCommit,
   // Layer API
@@ -162,6 +162,33 @@ describe('gridFillExtent', () => {
   });
 });
 
+describe('computeGridPositions', () => {
+  // The same math rebuildPositionSetGrid uses to actually commit a
+  // resize (see editBounPos/editEl below) — exposed separately so a live
+  // preview (overlay.js's updatePosSetGhost / app.js's previewField) can
+  // compute the identical result without touching Yjs.
+  test('circles match gridFillExtent for the same inputs', () => {
+    const extent = { x: 0, y: 0, w: 200, h: 200 };
+    const { circles } = computeGridPositions(extent, 'square', 50, 50, 2);
+    expect(circles).toEqual(gridFillExtent(0, 0, 200, 200, 'square', 50, 50));
+  });
+
+  test('r scales with snapRadius level (1 through 4)', () => {
+    const extent = { x: 0, y: 0, w: 200, h: 200 };
+    const radii = [1, 2, 3, 4].map(level => computeGridPositions(extent, 'square', 80, 80, level).r);
+    expect(radii[0]).toBeLessThan(radii[1]);
+    expect(radii[1]).toBeLessThan(radii[2]);
+    expect(radii[2]).toBeLessThan(radii[3]);
+  });
+
+  test('works for hex grids too', () => {
+    const extent = { x: 0, y: 0, w: 300, h: 300 };
+    const { circles, r } = computeGridPositions(extent, 'hex', 70, 60, 2);
+    expect(circles.length).toBeGreaterThan(0);
+    expect(r).toBeGreaterThan(0);
+  });
+});
+
 // ── CRDT operations ───────────────────────────────────────────────────────────
 
 describe('addBoundary / findEl', () => {
@@ -237,6 +264,42 @@ describe('editBounPos rename', () => {
     editBounPos({ id, name: 'forest' }, layer.ydoc, layer.yBounPos);
     expect(yEl.getAttribute('name')).toBe('forest');
     expect(findEl(layer.yBounPos, id).getAttribute('name')).toBe('forest');
+  });
+});
+
+describe('editBounPos grid resize (xSpacing/ySpacing/snapRadius)', () => {
+  // Locks in that the real commit path (rebuildPositionSetGrid, called
+  // via editBounPos/editEl) produces exactly what computeGridPositions
+  // predicts — the same parity a live ghost preview relies on to show a
+  // grid that matches what actually lands on release.
+  test('changing xSpacing rebuilds the circle set to match computeGridPositions', () => {
+    const layer = makeLayer();
+    const { id } = addPS(layer, { x: 0, y: 0, w: 200, h: 200, genType: 'square', xSpacing: 80, ySpacing: 80 });
+
+    editBounPos({ id, xSpacing: 50, ySpacing: 80 }, layer.ydoc, layer.yBounPos);
+
+    const yEl = findEl(layer.yBounPos, id);
+    const committedCircles = yEl.toArray()
+      .filter(c => c instanceof Y.XmlElement && c.nodeName === 'circle')
+      .map(c => ({ cx: Number(c.getAttribute('cx')), cy: Number(c.getAttribute('cy')) }));
+    const { circles: expectedCircles } = computeGridPositions({ x: 0, y: 0, w: 200, h: 200 }, 'square', 50, 80, 2);
+    expect(committedCircles).toEqual(expectedCircles);
+    expect(yEl.getAttribute('data-gen-x-spacing')).toBe('50');
+  });
+
+  test('changing snapRadius level updates every circle’s r to match computeGridPositions', () => {
+    const layer = makeLayer();
+    const { id } = addPS(layer, { x: 0, y: 0, w: 200, h: 200, genType: 'square', xSpacing: 80, ySpacing: 80 });
+
+    editBounPos({ id, snapRadius: 4 }, layer.ydoc, layer.yBounPos);
+
+    const yEl = findEl(layer.yBounPos, id);
+    const { r: expectedR } = computeGridPositions({ x: 0, y: 0, w: 200, h: 200 }, 'square', 80, 80, 4);
+    const committedRadii = yEl.toArray()
+      .filter(c => c instanceof Y.XmlElement && c.nodeName === 'circle')
+      .map(c => Number(c.getAttribute('r')));
+    expect(committedRadii.every(r => r === expectedR)).toBe(true);
+    expect(yEl.getAttribute('data-snap-radius')).toBe(String(expectedR));
   });
 });
 

--- a/tests/unit/boun_pos.test.js
+++ b/tests/unit/boun_pos.test.js
@@ -22,12 +22,14 @@ import {
   // Geometry queries
   getGeom, getAnchor,
   // Edit schema
-  getTtStateSchema, edit,
+  getTtStateSchema, edit, previewEdit,
   // Drag context
   computeBoundaryRects, getSnapPoints,
 } from '../../src/boun_pos.js';
 import { tablesAPI } from '../../src/tables.js';
 const { makeDoc } = tablesAPI;
+
+const SVG_NS = 'http://www.w3.org/2000/svg';
 
 // ── Helpers ───────────────────────────────────────────────────────────────────
 
@@ -58,6 +60,33 @@ function addPS(layer, overrides = {}) {
     ...overrides, id, name,
   });
   return { id, name, circles };
+}
+
+// Mirrors what overlay.js's startGhost clones from a rendered pos-set
+// element (see boun_pos.js's _positionSetToSVGEl): a <g data-bounpos-type
+// ="pos-set"> with its data-gen-*/data-snap-radius attributes, a <path>
+// (getGeom reads this for the extent), and N <circle fill="url(#...)">
+// children — the fill is what previewEdit's template-clone approach
+// exists to preserve.
+function makeGhostPosSet({ x = 0, y = 0, w = 200, h = 200, genType = 'square', xSpacing = 80, ySpacing = 80, snapRadius = 30, circleCount = 4 } = {}) {
+  const g = document.createElementNS(SVG_NS, 'g');
+  g.setAttribute('data-bounpos-type',   'pos-set');
+  g.setAttribute('data-gen-type',       genType);
+  g.setAttribute('data-gen-x-spacing',  String(xSpacing));
+  g.setAttribute('data-gen-y-spacing',  String(ySpacing));
+  g.setAttribute('data-snap-radius',    String(snapRadius));
+  const path = document.createElementNS(SVG_NS, 'path');
+  path.setAttribute('d', rectToPath(x, y, w, h));
+  g.appendChild(path);
+  for (let i = 0; i < circleCount; i++) {
+    const circle = document.createElementNS(SVG_NS, 'circle');
+    circle.setAttribute('cx', String(i * 50));
+    circle.setAttribute('cy', String(i * 50));
+    circle.setAttribute('r',  '10');
+    circle.setAttribute('fill', 'url(#snap-point-grad)');
+    g.appendChild(circle);
+  }
+  return g;
 }
 
 // ── ID helpers ─────────────────────────────────────────────────────────────────
@@ -164,9 +193,9 @@ describe('gridFillExtent', () => {
 
 describe('computeGridPositions', () => {
   // The same math rebuildPositionSetGrid uses to actually commit a
-  // resize (see editBounPos/editEl below) — exposed separately so a live
-  // preview (overlay.js's updatePosSetGhost / app.js's previewEdit) can
-  // compute the identical result without touching Yjs.
+  // resize (see editBounPos/editEl below) — exposed separately so this
+  // file's own previewEdit (tested further down) can compute the
+  // identical result without touching Yjs.
   test('circles match gridFillExtent for the same inputs', () => {
     const extent = { x: 0, y: 0, w: 200, h: 200 };
     const { circles } = computeGridPositions(extent, 'square', 50, 50, 2);
@@ -300,6 +329,84 @@ describe('editBounPos grid resize (xSpacing/ySpacing/snapRadius)', () => {
       .map(c => Number(c.getAttribute('r')));
     expect(committedRadii.every(r => r === expectedR)).toBe(true);
     expect(yEl.getAttribute('data-snap-radius')).toBe(String(expectedR));
+  });
+});
+
+describe('previewEdit', () => {
+  // This is the function that used to live as overlay.js's
+  // updatePosSetGhost — moved here so boun_pos.js is the only file that
+  // knows a pos-set's circles are derived from spacing/snapRadius, not a
+  // plain attribute. ghostEl mirrors the detached clone overlay.js's
+  // startGhost hands it — same shape as attr-ghost.test.js's harness, but
+  // exercised directly against this module instead of through Overlay.
+  test('replaces the circle children to match a new grid, preserving the fill from an existing circle', () => {
+    const ghostEl = makeGhostPosSet({ x: 0, y: 0, w: 200, h: 200, genType: 'square', xSpacing: 80, ySpacing: 80 });
+    // The level previewEdit itself derives off the ghost's own (unmutated)
+    // attributes — same call it makes internally.
+    const { snapRadius: level, ySpacing } = getTtStateSchema(ghostEl);
+
+    previewEdit(ghostEl, { xSpacing: 50 });
+
+    const { circles: expected, r: expectedR } = computeGridPositions({ x: 0, y: 0, w: 200, h: 200 }, 'square', 50, ySpacing, level);
+    const circles = [...ghostEl.querySelectorAll(':scope > circle')];
+    expect(circles).toHaveLength(expected.length);
+    expect(circles.map(c => [Number(c.getAttribute('cx')), Number(c.getAttribute('cy'))]))
+      .toEqual(expected.map(({ cx, cy }) => [Math.round(cx), Math.round(cy)]));
+    expect(circles.every(c => Number(c.getAttribute('r')) === Math.round(expectedR))).toBe(true);
+    // Template-cloned from an existing circle, so the gradient fill survives.
+    expect(circles.every(c => c.getAttribute('fill') === 'url(#snap-point-grad)')).toBe(true);
+  });
+
+  test('reads whichever of xSpacing/ySpacing/snapRadius are absent from editData off the ghost’s own attributes', () => {
+    const ghostEl = makeGhostPosSet({ x: 0, y: 0, w: 200, h: 200, genType: 'square', xSpacing: 80, ySpacing: 80 });
+    const { snapRadius: level, xSpacing } = getTtStateSchema(ghostEl);
+
+    // Only ySpacing is previewed; xSpacing/snapRadius should come from the
+    // ghost's current data-gen-x-spacing/data-snap-radius attributes.
+    previewEdit(ghostEl, { ySpacing: 40 });
+
+    const { circles: expected } = computeGridPositions({ x: 0, y: 0, w: 200, h: 200 }, 'square', xSpacing, 40, level);
+    const circles = [...ghostEl.querySelectorAll(':scope > circle')];
+    expect(circles.map(c => [Number(c.getAttribute('cx')), Number(c.getAttribute('cy'))]))
+      .toEqual(expected.map(({ cx, cy }) => [Math.round(cx), Math.round(cy)]));
+  });
+
+  test('the <path> child is left untouched', () => {
+    const ghostEl = makeGhostPosSet({ x: 0, y: 0, w: 200, h: 200 });
+    const d = ghostEl.querySelector('path').getAttribute('d');
+
+    previewEdit(ghostEl, { xSpacing: 20 });
+
+    expect(ghostEl.querySelector('path').getAttribute('d')).toBe(d);
+  });
+
+  test('falls back to a bare circle (no fill) if the ghost started with zero circles', () => {
+    const ghostEl = makeGhostPosSet({ x: 0, y: 0, w: 50, h: 50, circleCount: 0 });
+
+    previewEdit(ghostEl, { xSpacing: 40, ySpacing: 40 });
+
+    const circles = [...ghostEl.querySelectorAll(':scope > circle')];
+    expect(circles.length).toBeGreaterThan(0);
+    expect(circles[0].hasAttribute('fill')).toBe(false);
+  });
+
+  test('is a no-op for a boundary ghost (no spacing/snapRadius to preview)', () => {
+    const ghostEl = document.createElementNS(SVG_NS, 'g');
+    ghostEl.setAttribute('data-bounpos-type', 'boundary');
+    const path = document.createElementNS(SVG_NS, 'path');
+    path.setAttribute('d', rectToPath(0, 0, 100, 100));
+    ghostEl.appendChild(path);
+
+    expect(() => previewEdit(ghostEl, { name: 'dungeon' })).not.toThrow();
+    expect(ghostEl.querySelectorAll('circle')).toHaveLength(0);
+  });
+
+  test('is a no-op when editData has none of xSpacing/ySpacing/snapRadius', () => {
+    const ghostEl = makeGhostPosSet({ circleCount: 3 });
+
+    previewEdit(ghostEl, { name: 'grid' });
+
+    expect(ghostEl.querySelectorAll(':scope > circle')).toHaveLength(3);
   });
 });
 

--- a/tests/unit/range_ticked.test.js
+++ b/tests/unit/range_ticked.test.js
@@ -114,6 +114,30 @@ test('dragging fires range-changed with the new numeric value on every input tic
   expect(received).toEqual([{ value: 12 }, { value: 13 }])
 })
 
+test('range-committed fires once on the native "change" (gesture end), not on every input tick', () => {
+  const el = makeRangeTicked({ min: '1', max: '25', step: '1', value: '5' })
+  const input = el.shadowRoot.querySelector('input')
+  const changed   = []
+  const committed = []
+  el.addEventListener('range-changed',   e => changed.push(e.detail))
+  el.addEventListener('range-committed', e => committed.push(e.detail))
+
+  // Three ticks of a drag...
+  input.value = '10'
+  input.dispatchEvent(new Event('input', { bubbles: true }))
+  input.value = '15'
+  input.dispatchEvent(new Event('input', { bubbles: true }))
+  input.value = '19'
+  input.dispatchEvent(new Event('input', { bubbles: true }))
+  expect(changed).toHaveLength(3)
+  expect(committed).toHaveLength(0) // nothing committed mid-drag
+
+  // ...then the mouse is released — the browser fires 'change' once.
+  input.dispatchEvent(new Event('change', { bubbles: true }))
+  expect(committed).toEqual([{ value: 19 }])
+  expect(changed).toHaveLength(3) // 'change' does not also re-fire range-changed
+})
+
 test('dragging reflects the new value onto .value/getValue()/the value attribute', () => {
   const el = makeRangeTicked({ min: '1', max: '25', step: '1', value: '5' })
   const input = el.shadowRoot.querySelector('input')

--- a/tests/unit/ui.test.js
+++ b/tests/unit/ui.test.js
@@ -201,6 +201,44 @@ describe('SELECT_TOOL multi option — show surfaces', () => {
     div.remove()
   })
 
+  test('an edit-mode <range-ticked>: range-changed previews (no commitEdit), range-committed commits — never calls App.commitEdit directly on every tick', () => {
+    // The whole point of previewField/commitFieldPreview (see app.js) is
+    // that App.commitEdit — which synchronously rebuilds #panelBody via
+    // UI.refreshFromDoc() — must NOT run on every drag tick, or it tears
+    // down the very <range-ticked> the user is dragging. So 'range-changed'
+    // (fires continuously) must go to previewField, a local-only ghost
+    // preview, and only 'range-committed' (fires once, gesture end) may
+    // call commitEdit — via commitFieldPreview.
+    const element = {
+      ...SHAPE_TYPES.rect.schema.values,
+      ltype: 'drawing', id: 'shape1', label: SHAPE_TYPES.rect.schema.label,
+      types: SHAPE_TYPES.rect.schema.types,
+      'stroke-width': 2,
+    }
+    const html = editBody({ element })
+    const div = document.createElement('div')
+    div.innerHTML = html
+    document.body.appendChild(div)
+    const commitEdit       = vi.fn()
+    const previewField     = vi.fn()
+    const commitFieldPreview = vi.fn()
+    init({ commitEdit, previewField, commitFieldPreview })
+    wireRangeTicked(div)
+
+    const rt = [...div.querySelectorAll('range-ticked')].find(el => el.dataset.rtKey === 'stroke-width')
+    rt.dispatchEvent(new CustomEvent('range-changed', { detail: { value: 4 }, bubbles: true, composed: true }))
+    rt.dispatchEvent(new CustomEvent('range-changed', { detail: { value: 5 }, bubbles: true, composed: true }))
+    expect(previewField).toHaveBeenNthCalledWith(1, 'shape1', 'stroke-width', 4)
+    expect(previewField).toHaveBeenNthCalledWith(2, 'shape1', 'stroke-width', 5)
+    expect(commitEdit).not.toHaveBeenCalled()
+
+    rt.dispatchEvent(new CustomEvent('range-committed', { detail: { value: 5 }, bubbles: true, composed: true }))
+    expect(commitFieldPreview).toHaveBeenCalledWith('shape1', 'stroke-width', 5)
+    expect(commitEdit).not.toHaveBeenCalled() // commitFieldPreview owns calling commitEdit itself, not wireRangeTicked
+
+    div.remove()
+  })
+
   test('editBody renders drawing stroke-width (rect/circle) as a <range-ticked min=0.5 max=10 step=0.5> — 0 is excluded since stroke is toggled off via the stroke color control, not width', () => {
     for (const type of ['rect', 'circle']) {
       const element = {

--- a/tests/unit/ui.test.js
+++ b/tests/unit/ui.test.js
@@ -201,14 +201,15 @@ describe('SELECT_TOOL multi option — show surfaces', () => {
     div.remove()
   })
 
-  test('an edit-mode <range-ticked>: range-changed previews (no commitEdit), range-committed commits — never calls App.commitEdit directly on every tick', () => {
-    // The whole point of previewField/commitFieldPreview (see app.js) is
-    // that App.commitEdit — which synchronously rebuilds #panelBody via
-    // UI.refreshFromDoc() — must NOT run on every drag tick, or it tears
-    // down the very <range-ticked> the user is dragging. So 'range-changed'
-    // (fires continuously) must go to previewField, a local-only ghost
-    // preview, and only 'range-committed' (fires once, gesture end) may
-    // call commitEdit — via commitFieldPreview.
+  test('an edit-mode <range-ticked>: range-changed previews (no commitEdit), range-committed calls the ordinary App.commitEdit(id, editData)', () => {
+    // The whole point of previewEdit (see app.js) is that App.commitEdit —
+    // which synchronously rebuilds #panelBody via UI.refreshFromDoc() —
+    // must NOT run on every drag tick, or it tears down the very
+    // <range-ticked> the user is dragging. So 'range-changed' (fires
+    // continuously) must go to previewEdit, a local-only ghost preview,
+    // and only 'range-committed' (fires once, gesture end) may call the
+    // same commitEdit(id, editData) every other Edit-panel field already
+    // uses — no separate "commit the preview" entry point.
     const element = {
       ...SHAPE_TYPES.rect.schema.values,
       ltype: 'drawing', id: 'shape1', label: SHAPE_TYPES.rect.schema.label,
@@ -219,22 +220,20 @@ describe('SELECT_TOOL multi option — show surfaces', () => {
     const div = document.createElement('div')
     div.innerHTML = html
     document.body.appendChild(div)
-    const commitEdit       = vi.fn()
-    const previewField     = vi.fn()
-    const commitFieldPreview = vi.fn()
-    init({ commitEdit, previewField, commitFieldPreview })
+    const commitEdit   = vi.fn()
+    const previewEdit   = vi.fn()
+    init({ commitEdit, previewEdit })
     wireRangeTicked(div)
 
     const rt = [...div.querySelectorAll('range-ticked')].find(el => el.dataset.rtKey === 'stroke-width')
     rt.dispatchEvent(new CustomEvent('range-changed', { detail: { value: 4 }, bubbles: true, composed: true }))
     rt.dispatchEvent(new CustomEvent('range-changed', { detail: { value: 5 }, bubbles: true, composed: true }))
-    expect(previewField).toHaveBeenNthCalledWith(1, 'shape1', 'stroke-width', 4)
-    expect(previewField).toHaveBeenNthCalledWith(2, 'shape1', 'stroke-width', 5)
+    expect(previewEdit).toHaveBeenNthCalledWith(1, 'shape1', { 'stroke-width': 4 })
+    expect(previewEdit).toHaveBeenNthCalledWith(2, 'shape1', { 'stroke-width': 5 })
     expect(commitEdit).not.toHaveBeenCalled()
 
     rt.dispatchEvent(new CustomEvent('range-committed', { detail: { value: 5 }, bubbles: true, composed: true }))
-    expect(commitFieldPreview).toHaveBeenCalledWith('shape1', 'stroke-width', 5)
-    expect(commitEdit).not.toHaveBeenCalled() // commitFieldPreview owns calling commitEdit itself, not wireRangeTicked
+    expect(commitEdit).toHaveBeenCalledWith('shape1', { 'stroke-width': 5 })
 
     div.remove()
   })


### PR DESCRIPTION
Reproduces the strategy discussed for the stroke-width drag bug: while dragging, preview on a detached ghost clone (Overlay layer) instead of writing to Yjs; commit to Yjs once, on release.

Root cause recap: an 'edit'-mode range-ticked's 'range-changed' fired App.commitEdit on every input tick. commitEdit writes to Yjs, which synchronously triggers UI.refreshFromDoc(), which replaces #panelBody's whole innerHTML — including the very <range-ticked> element mid-drag, killing the browser's native slider-drag tracking on it.

- component/range_ticked.js: new 'range-committed' event, firing once on the internal <input>'s native 'change' (gesture end) rather than every 'input' tick. Existing 'range-changed' behavior is untouched.
- overlay.js: new startAttrGhost/updateAttrGhost/endAttrGhost, mirroring the existing startResizeGhost/updateResizeGhost/endResizeGhost pattern (a detached clone survives renderDoc()'s full layer rebuild, the real element cannot). Simpler than the resize ghost's two-copy scheme: since nothing moves or resizes, the placeholder and the ghost sit at the same footprint, so the ghost (z-top) fully occludes both the placeholder and the real element underneath — no separate hide/show step needed.
- app.js: new App.previewField/commitFieldPreview/cancelFieldPreview, same shape as the startResize/resize/commitResize/cancelResize lifecycle. previewField resolves a schema key to its real SVG attribute name via drawing.js's SHAPE_TYPES attrMap (e.g. corner-r -> rx) before updating the ghost — for fields with no such mapping (e.g. boun_pos's snapRadius) the ghost preview is a harmless no-op, but the actual bug fix (no Yjs write until release) still applies uniformly to every edit-mode range-ticked field.
- ui.js: wireRangeTicked's 'edit' branch now wires 'range-changed' to previewField (local-only) and 'range-committed' to commitFieldPreview (the real, once-only Yjs write). 'add'/ 'addQuick'/'checkpoint' fields are untouched — they never triggered a re-render to begin with.


Also discovered, but explicitly NOT fixing here (pre-existing, unrelated to this branch, exposed only because a real end-to-end commit check for corner-r didn't previously exist): drawing.js's edit() — the function under App.commitEdit — never applied the attrMap translation the way addDrawing() does at creation time, so committing a corner-r edit has never actually updated the rendered rx. stroke-width has no attrMap entry, so this never affected it.


Claude-Session: https://claude.ai/code/session_01LbbrghWbKfXdXg5ZnaeKeW