### PR TITLE
Trace signaling relay traffic to diagnose stuck peer connections

### DIFF
--- a/src/app.js
+++ b/src/app.js
@@ -471,6 +471,28 @@ export function boot({ ydoc, awareness, provider, myId, myGrad, tableId, isCreat
     }
   });
 
+  // Raw signaling relay traffic (announce/signal), one layer below 'peers'.
+  // 'peers' only fires once an announce has actually been relayed back to
+  // us — its absence looks identical whether the signaling server never
+  // bridged the two sides, or it did and ICE negotiation failed after.
+  // Tracing the relay messages themselves tells those apart.
+  _provider.signalingConns.forEach(conn => {
+    conn.on('message', (m) => {
+      if (m?.type !== 'publish' || m.topic !== tableId) return;
+      const data = m.data;
+      const mine = data?.from === _provider.room?.peerId;
+      if (data?.type === 'announce') {
+        Trace.net(mine ? 'announce-sent' : 'announce-received',
+          mine ? 'announced ourselves to the room' : `peer announced itself: ${data.from}`,
+          { peerId: data.from });
+      } else if (data?.type === 'signal') {
+        Trace.net(mine ? 'signal-sent' : 'signal-received',
+          `${data.signal?.type ?? 'signal'} ${mine ? 'to' : 'from'} ${mine ? data.to : data.from}`,
+          { from: data.from, to: data.to, kind: data.signal?.type });
+      }
+    });
+  });
+
   // Initial render
   renderDoc();
   renderPresence();

--- a/tests/unit/bowstring-resize-mode.integration.test.js
+++ b/tests/unit/bowstring-resize-mode.integration.test.js
@@ -105,7 +105,7 @@ async function bootApp() {
 
   boot({
     ydoc,
-    awareness, provider: { on: vi.fn() },
+    awareness, provider: { on: vi.fn(), signalingConns: [] },
     myId: 'bailey', myGrad, tableId: 'test-room', isCreator: true,
     svgElement: svgEl, displayName: 'Bailey',
   })

--- a/tests/unit/soft-lock.integration.test.js
+++ b/tests/unit/soft-lock.integration.test.js
@@ -111,7 +111,7 @@ async function bootPeerB(extraToys = []) {
 
   boot({
     ydoc,
-    awareness, provider: { on: vi.fn() },
+    awareness, provider: { on: vi.fn(), signalingConns: [] },
     myId: 'bailey', myGrad, tableId: 'test-room', isCreator: true,
     svgElement: svgEl, displayName: 'Bailey',
   })

--- a/tests/unit/undo-selection.integration.test.js
+++ b/tests/unit/undo-selection.integration.test.js
@@ -101,7 +101,7 @@ async function bootApp() {
 
   boot({
     ydoc,
-    awareness, provider: { on: vi.fn() },
+    awareness, provider: { on: vi.fn(), signalingConns: [] },
     myId: 'bailey', myGrad, tableId: 'test-room', isCreator: true,
     svgElement: svgEl, displayName: 'Bailey',
   })


### PR DESCRIPTION
'peers' only fires after the signaling server has already relayed an announce back to us, so its absence looks identical whether the server never bridged two clients or it did and ICE negotiation failed after. Tracing the raw announce/signal relay messages on the net channel tells those apart, which is what's needed to root-cause reports like "signaling connected on both clients but neither ever sees the other."

Update the three integration tests that hand boot() a stub provider to include signalingConns: [], matching the real WebrtcProvider's shape.