### PR TITLE
Add hashchange listener so index.html joins/creates tables on hash ch…

### DIFF
--- a/src/index.html
+++ b/src/index.html
@@ -229,6 +229,19 @@ document.getElementById('tableLabel').textContent = tableId;
 Trace.boot('table-id', isCreator ? `minted a new table: ${tableId}` : `joining table: ${tableId}`,
   { tableId, isCreator, hash: location.hash });
 
+// Leave this table and join/create whatever table the hash names next —
+// a peer editing the URL bar, browser back/forward, or a same-page link to
+// another #tableId all land here. A full reload re-runs the creator/joiner
+// logic above from scratch, so nothing here needs to hand-unwind this
+// table's provider, doc, or DOM listeners.
+// Guarded against the creator mint just above: setting location.hash there
+// queues its own hashchange, which would otherwise reload a table that
+// just finished booting.
+window.addEventListener('hashchange', () => {
+  if (location.hash.slice(1) === tableId) return;
+  location.reload();
+});
+
 const ydoc  = await tables.getYDoc(tableId);
 App.addLog('loaded from indexeddb', 'local');
 tables.touchTableRecord(tableId);

--- a/tests/e2e/hashchange.spec.js
+++ b/tests/e2e/hashchange.spec.js
@@ -1,0 +1,69 @@
+/**
+ * tests/e2e/hashchange.spec.js
+ *
+ * index.html reads location.hash exactly once, at boot, to decide which
+ * table to create/join (see helpers.js's doc comment). Anything that
+ * changes the hash afterward — the user editing the URL bar, browser
+ * back/forward, a same-page link to another #tableId — used to leave the
+ * page showing the OLD table forever, per the comment on
+ * ui.js's branchDialogKeepWorking. The hashchange listener added to
+ * index.html closes that gap by reloading onto whatever table the hash
+ * names now.
+ */
+
+import { test, expect, chromium } from '@playwright/test';
+import { openAsCreator } from './helpers.js';
+
+const APP_URL       = process.env.APP_URL       || 'http://localhost:3000';
+const SIGNALING_URL = process.env.SIGNALING_URL || 'ws://localhost:4444';
+
+test.describe('hashchange table navigation', () => {
+  test('the creator\'s own initial hash-mint does not trigger a reload', async () => {
+    const browser = await chromium.launch({ executablePath: process.env.PW_CHROME, args: ['--no-sandbox', '--disable-dev-shm-usage'] });
+    const page    = await browser.newPage();
+
+    // sessionStorage survives a same-page reload, so a counter bumped by
+    // every fresh script execution tells reloads apart from the single
+    // initial load.
+    await page.addInitScript(() => {
+      sessionStorage.setItem('__loads', String(Number(sessionStorage.getItem('__loads') || '0') + 1));
+    });
+
+    const room = await openAsCreator(page, { appUrl: APP_URL, signalingUrl: SIGNALING_URL });
+    await expect(page.locator('#tableLabel')).toHaveText(room);
+    await page.waitForTimeout(300); // give a spurious hashchange reload a chance to happen
+
+    expect(await page.evaluate(() => sessionStorage.getItem('__loads'))).toBe('1');
+
+    await browser.close();
+  });
+
+  test('changing the hash on an open page leaves the current table and joins the new one', async () => {
+    const browser = await chromium.launch({ executablePath: process.env.PW_CHROME, args: ['--no-sandbox', '--disable-dev-shm-usage'] });
+    const page    = await browser.newPage();
+
+    await page.addInitScript(() => {
+      sessionStorage.setItem('__loads', String(Number(sessionStorage.getItem('__loads') || '0') + 1));
+    });
+
+    const tableA = await openAsCreator(page, { appUrl: APP_URL, signalingUrl: SIGNALING_URL });
+    await expect(page.locator('#tableLabel')).toHaveText(tableA);
+    expect(await page.evaluate(() => sessionStorage.getItem('__loads'))).toBe('1');
+
+    const tableB = 'tt-T-v1-e2ehashtest';
+    await page.evaluate((id) => { location.hash = id; }, tableB);
+
+    // The listener reloads the page onto tableB; the status bar reflects
+    // whatever table is currently booted, so it's the signal that the
+    // reload landed and the new table's boot ran.
+    await expect(page.locator('#tableLabel')).toHaveText(tableB, { timeout: 8000 });
+    await expect.poll(() => page.evaluate(() => location.hash.slice(1))).toBe(tableB);
+
+    // Exactly one reload happened — not zero (the hash change was ignored)
+    // and not more than one (no reload loop from the listener re-triggering
+    // itself).
+    expect(await page.evaluate(() => sessionStorage.getItem('__loads'))).toBe('2');
+
+    await browser.close();
+  });
+});


### PR DESCRIPTION
…ange

Previously the app read location.hash only once at boot; a same-page hash change (URL bar edit, back/forward, a link to another #tableId) left the old table's session running forever, per the comment on ui.js's branchDialogKeepWorking. A global hashchange listener now reloads onto whatever table the hash names, guarded against the creator's own initial hash-mint so table creation doesn't trigger a spurious reload.


Claude-Session: https://claude.ai/code/session_01VYm95TfhQftZKCVHCpX3z9