### PR TITLE
Fix 'signaling connected' to reflect the real WebSocket, not provider state

### DIFF
--- a/src/app.js
+++ b/src/app.js
@@ -449,7 +449,13 @@ export function boot({ ydoc, awareness, provider, myId, myGrad, tableId, isCreat
     UI.toast('Synced with peers');
     App.addLog('synced with peers', 'remote');
   });
-  _provider.on('status', ({ connected }) => {
+  // Deliberately NOT the library's own 'status' event: that reflects
+  // provider.connected (room !== null && shouldConnect), which goes true
+  // moments after construction whether or not the underlying WebSocket
+  // ever actually opens — "signaling connected" looked fine while the
+  // socket to the signaling server had never succeeded. Track the
+  // SignalingConn's own connect/disconnect (the real transport) instead.
+  const setSignalingConnected = (connected) => {
     if (dot) dot.className = connected ? 'status-dot connected' : 'status-dot connecting';
     _netStatus.connected = connected;
     Trace.net('status', connected ? 'signaling connected' : 'signaling disconnected',
@@ -457,7 +463,7 @@ export function boot({ ydoc, awareness, provider, myId, myGrad, tableId, isCreat
     // Cancel any in-progress drag on disconnect — doc stays at committed position.
     if (!connected && _dragState) App.cancelMove();
     if (!connected && _multiDragState) App.cancelMultiMove();
-  });
+  };
   // y-webrtc's own peer bookkeeping — the WebRTC handshakes themselves,
   // which awareness only reflects indirectly and after the fact.
   _provider.on('peers', ({ added = [], removed = [], webrtcPeers = [], bcPeers = [] }) => {
@@ -477,6 +483,8 @@ export function boot({ ydoc, awareness, provider, myId, myGrad, tableId, isCreat
   // bridged the two sides, or it did and ICE negotiation failed after.
   // Tracing the relay messages themselves tells those apart.
   _provider.signalingConns.forEach(conn => {
+    conn.on('connect', () => setSignalingConnected(true));
+    conn.on('disconnect', () => setSignalingConnected(false));
     conn.on('message', (m) => {
       if (m?.type !== 'publish' || m.topic !== tableId) return;
       const data = m.data;


### PR DESCRIPTION
## Summary

- Follow-up to #117's signaling-relay tracing, while chasing a live-site "two clients never see each other" bug.
- `_provider.on('status', ...)` was reading y-webrtc's `provider.connected` getter, which is just `room !== null && shouldConnect` — true within milliseconds of construction *regardless of whether the underlying WebSocket to the signaling server ever actually opens*. Every debug trace pulled during this investigation showed `"signaling connected": true` (against both the default fly.dev relay and a freshly stood-up custom server) even though zero announce/signal traffic ever flowed on either — the indicator wasn't measuring what its label claims.
- Drives the status dot / `net.connected` field / `Trace.net('status', ...)` from the `SignalingConn`'s own real `connect`/`disconnect` WebSocket events instead (exposed via `provider.signalingConns`, already tapped in this file for the announce/signal tracing added in #117). Same field, same trace event, correctly sourced — the status dot and drag-cancel-on-disconnect behavior pick up the fix for free.

## Test plan

- [x] `npx vitest run` — 1054 tests passing
- [x] `bin/test_e2e.sandbox.sh tests/e2e/sync.spec.js` — 4/4 passing
- [x] Manually verified against a local signaling server (two real Chromium tabs): full `announce-sent → peer-connected → announce-received → signal-sent/received → synced` sequence still traces correctly after the change

🤖 Generated with [Claude Code](https://claude.ai/code)

https://claude.ai/code/session_01189n9ESJuLHWgNeGk3ELYn

---
_Generated by [Claude Code](https://claude.ai/code/session_01189n9ESJuLHWgNeGk3ELYn)_