### PR TITLE
Fix joinSequence race: a joiner could land ahead of the table's creator

### DIFF
--- a/src/index.html
+++ b/src/index.html
@@ -248,8 +248,10 @@ tables.touchTableRecord(tableId);
 
 // Join the authority ordering only now that the local IndexedDB replay has
 // landed — ensureJoined's guard needs to see this table's *existing*
-// joinSequence
-tables.ensureJoined(ydoc, myId);
+// joinSequence. isCreator tells it whether an empty joinSequence means
+// "brand new table" or "haven't synced with the creator yet" (see
+// tables.js's ensureJoined).
+tables.ensureJoined(ydoc, myId, { isCreator });
 
 // ── WebRTC  ─────────────────────────────────────────────────────────────────
 const signalingUrls = resolveSignalingServers();

--- a/src/tables.js
+++ b/src/tables.js
@@ -71,20 +71,52 @@ function getJoinSequenceArray(ydoc) {
 /**
  * Append myId to this table's join sequence, only if not already
  * present. Safe to call every session.
+ *
+ * isCreator is the same signal index.html already computes for the op
+ * log's genesis checkpoint (toys.js's projectLayer): !location.hash,
+ * decided once at the top of boot. It matters only when the local
+ * joinSequence is currently empty — indistinguishable, from this peer's
+ * own replica, between "this table has genuinely just come into being"
+ * and "the creator's own join hasn't synced in over the wire yet".
+ *
+ * A joiner (isCreator: false) who inserted anyway in that second case
+ * would race the creator's not-yet-arrived entry as a concurrent Y.Array
+ * insert — and Yjs's CRDT tie-break for that race doesn't honor
+ * real-world join order, so the joiner could land ahead of the creator.
+ * (CONCURRENCY_AND_BRANCHING.md: "Bias toward the table's creator is
+ * intentional.") So a joiner facing an empty joinSequence defers instead,
+ * and retries once the array actually changes — either the creator's
+ * entry lands, or (rarer) another joiner's does, and either way this
+ * peer then correctly appends after it. A joiner who never sees the
+ * array change (no peer ever online) never joins — the same fate as
+ * projectLayer's non-creator-with-empty-log path.
  */
-function ensureJoined(ydoc, myId) {
+function ensureJoined(ydoc, myId, { isCreator = false } = {}) {
   const yJoinSequence = getJoinSequence(ydoc);
-  if (yJoinSequence.toArray().includes(myId)) return;
-  ydoc.transact(() => {
-    // Re-check inside the transaction in case something else already
-    // appended this id while this call was in flight (e.g. a duplicate
-    // ensureJoined call from a second boot path). Concurrent joins from
-    // *other* peers are a different id and never collide with this guard.
+
+  const attempt = () => {
     if (yJoinSequence.toArray().includes(myId)) return;
-    yJoinSequence.push([myId]);
-  });
-  Trace.boot('join', `joined the authority ordering at index ${yJoinSequence.toArray().indexOf(myId)}`,
-    { myId, joinSequence: yJoinSequence.toArray() });
+    if (yJoinSequence.length === 0 && !isCreator) {
+      const retry = () => {
+        yJoinSequence.unobserve(retry);
+        attempt();
+      };
+      yJoinSequence.observe(retry);
+      return;
+    }
+    ydoc.transact(() => {
+      // Re-check inside the transaction in case something else already
+      // appended this id while this call was in flight (e.g. a duplicate
+      // ensureJoined call from a second boot path). Concurrent joins from
+      // *other* peers are a different id and never collide with this guard.
+      if (yJoinSequence.toArray().includes(myId)) return;
+      yJoinSequence.push([myId]);
+    });
+    Trace.boot('join', `joined the authority ordering at index ${yJoinSequence.toArray().indexOf(myId)}`,
+      { myId, joinSequence: yJoinSequence.toArray() });
+  };
+
+  attempt();
 }
 
 /**

--- a/tests/e2e/sync.spec.js
+++ b/tests/e2e/sync.spec.js
@@ -151,6 +151,48 @@ test.describe('two-peer sync', () => {
     await browser.close();
   });
 
+  // This doesn't reproduce the actual race (the unit tests in
+  // tests/unit/tables-authority.test.js do that deterministically, by
+  // controlling the order updates are applied in) — a same-machine
+  // WebRTC handshake is fast enough that page1's join entry is usually
+  // already committed before page2's boot script even runs. What this
+  // does check is the wiring: that index.html actually threads isCreator
+  // through to ensureJoined, and that the Debug tab renders the resulting
+  // joinSequence identically on both peers.
+  test('the creator sorts before a joiner in the joinSequence, on both peers', async () => {
+    const browser = await chromium.launch({ executablePath: process.env.PW_CHROME, args: ['--no-sandbox','--disable-dev-shm-usage'] });
+    const ctx1    = await browser.newContext();
+    const ctx2    = await browser.newContext();
+    const page1   = await ctx1.newPage();
+    const page2   = await ctx2.newPage();
+
+    await openCreatorAndJoiner(page1, page2, { appUrl: APP_URL, signalingUrl: SIGNALING_URL });
+
+    await expect(page1.locator('#peerCount')).toHaveText('1', { timeout: 8000 });
+    await expect(page2.locator('#peerCount')).toHaveText('1', { timeout: 8000 });
+
+    // Open the Debug tab on both peers, which renders the joinSequence as
+    // an ordered ladder (debug_panel.js's joinSequenceHTML).
+    await page1.evaluate(() => window.UI.openSheet('debug'));
+    await page2.evaluate(() => window.UI.openSheet('debug'));
+
+    const readJoinSequence = (page) =>
+      page.$$eval('.dbg-join-row .dbg-id', els => els.map(el => el.textContent));
+
+    // Both replicas must converge to the identical order, and the table's
+    // creator (page1) — not the joiner (page2) — must be first: bug was
+    // the joiner racing ahead of the creator's not-yet-synced entry.
+    await expect.poll(() => readJoinSequence(page1)).toHaveLength(2);
+    const seq1 = await readJoinSequence(page1);
+    const seq2 = await readJoinSequence(page2);
+    expect(seq1).toEqual(seq2);
+
+    await expect(page1.locator('.dbg-join-row.me .dbg-join-i')).toHaveText('0');
+    await expect(page2.locator('.dbg-join-row.me .dbg-join-i')).toHaveText('1');
+
+    await browser.close();
+  });
+
   test('no console errors or warnings on load', async ({ page }) => {
     const messages = [];
     page.on('console', msg => {

--- a/tests/unit/tables-authority.test.js
+++ b/tests/unit/tables-authority.test.js
@@ -19,23 +19,40 @@ function rawJoinSequence(ydoc) {
 }
 
 describe('ensureJoined', () => {
-  test('appends a fresh id', () => {
+  test('the creator appends a fresh id to an empty joinSequence', () => {
     const ydoc = new Y.Doc()
-    ensureJoined(ydoc, 'tt-p-v1-01-aaa')
+    ensureJoined(ydoc, 'tt-p-v1-01-aaa', { isCreator: true })
     expect(rawJoinSequence(ydoc).toArray()).toEqual(['tt-p-v1-01-aaa'])
+  })
+
+  test('a joiner (isCreator: false) defers on an empty joinSequence instead of inserting', () => {
+    const ydoc = new Y.Doc()
+    ensureJoined(ydoc, 'peer-B')
+    expect(rawJoinSequence(ydoc).toArray()).toEqual([])
+  })
+
+  test('a deferred joiner catches up once the array changes — e.g. the creator syncs in', () => {
+    const ydoc = new Y.Doc()
+    ensureJoined(ydoc, 'peer-B') // defers: joinSequence is still empty
+    expect(rawJoinSequence(ydoc).toArray()).toEqual([])
+
+    // The creator's entry arrives (e.g. over the wire, mid-session).
+    rawJoinSequence(ydoc).push(['peer-A'])
+
+    expect(rawJoinSequence(ydoc).toArray()).toEqual(['peer-A', 'peer-B'])
   })
 
   test('is idempotent — calling again for the same id does not re-append', () => {
     const ydoc = new Y.Doc()
-    ensureJoined(ydoc, 'tt-p-v1-01-aaa')
-    ensureJoined(ydoc, 'tt-p-v1-01-aaa')
-    ensureJoined(ydoc, 'tt-p-v1-01-aaa')
+    ensureJoined(ydoc, 'tt-p-v1-01-aaa', { isCreator: true })
+    ensureJoined(ydoc, 'tt-p-v1-01-aaa', { isCreator: true })
+    ensureJoined(ydoc, 'tt-p-v1-01-aaa', { isCreator: true })
     expect(rawJoinSequence(ydoc).toArray()).toEqual(['tt-p-v1-01-aaa'])
   })
 
   test('preserves join order across multiple distinct peers', () => {
     const ydoc = new Y.Doc()
-    ensureJoined(ydoc, 'peer-A')
+    ensureJoined(ydoc, 'peer-A', { isCreator: true })
     ensureJoined(ydoc, 'peer-B')
     ensureJoined(ydoc, 'peer-C')
     expect(rawJoinSequence(ydoc).toArray()).toEqual(['peer-A', 'peer-B', 'peer-C'])
@@ -43,40 +60,66 @@ describe('ensureJoined', () => {
 
   test('a returning peer (reload) keeps its original position, not appended again', () => {
     const ydoc = new Y.Doc()
-    ensureJoined(ydoc, 'peer-A')
+    ensureJoined(ydoc, 'peer-A', { isCreator: true })
     ensureJoined(ydoc, 'peer-B')
     // Simulate peer-A reloading and re-joining.
-    ensureJoined(ydoc, 'peer-A')
+    ensureJoined(ydoc, 'peer-A', { isCreator: true })
     expect(rawJoinSequence(ydoc).toArray()).toEqual(['peer-A', 'peer-B'])
   })
 })
 
 describe('ensureJoined — concurrent joins across two replicas', () => {
-  test('two peers joining concurrently converge to the same order on both replicas', () => {
-    const docA = new Y.Doc()
-    const docB = new Y.Doc()
+  test('the creator always lands first, even when a joiner races ahead of sync', () => {
+    const docA = new Y.Doc() // the table's creator
+    const docB = new Y.Doc() // a joiner, arriving before docA's entry syncs in
 
-    // Neither peer has seen the other yet — both append concurrently.
-    ensureJoined(docA, 'peer-A')
-    ensureJoined(docB, 'peer-B')
+    ensureJoined(docA, 'peer-A', { isCreator: true })
+    ensureJoined(docB, 'peer-B') // defers: docB's local joinSequence is still empty
 
-    // Sync both directions.
-    const updateA = Y.encodeStateAsUpdate(docA)
-    const updateB = Y.encodeStateAsUpdate(docB)
-    Y.applyUpdate(docA, updateB)
-    Y.applyUpdate(docB, updateA)
+    // docA's entry reaches docB first, firing docB's deferred retry — which
+    // appends peer-B locally, after peer-A.
+    Y.applyUpdate(docB, Y.encodeStateAsUpdate(docA))
+    // A real WebRTC session keeps syncing after that first exchange, so
+    // docB's now-complete state reaches docA too.
+    Y.applyUpdate(docA, Y.encodeStateAsUpdate(docB))
 
     const seqA = rawJoinSequence(docA).toArray()
     const seqB = rawJoinSequence(docB).toArray()
     expect(seqA).toEqual(seqB)
-    expect([...seqA].sort()).toEqual(['peer-A', 'peer-B'])
+    expect(seqA).toEqual(['peer-A', 'peer-B'])
+  })
+
+  test('two non-creator joiners racing an already-synced creator tie-break arbitrarily but consistently', () => {
+    const docA = new Y.Doc()
+    ensureJoined(docA, 'peer-A', { isCreator: true })
+
+    const docB = new Y.Doc()
+    const docC = new Y.Doc()
+    Y.applyUpdate(docB, Y.encodeStateAsUpdate(docA))
+    Y.applyUpdate(docC, Y.encodeStateAsUpdate(docA))
+
+    // Both joiners see peer-A already present, so neither defers — they
+    // race each other, not the creator.
+    ensureJoined(docB, 'peer-B')
+    ensureJoined(docC, 'peer-C')
+
+    const updateB = Y.encodeStateAsUpdate(docB)
+    const updateC = Y.encodeStateAsUpdate(docC)
+    Y.applyUpdate(docB, updateC)
+    Y.applyUpdate(docC, updateB)
+
+    const seqB = rawJoinSequence(docB).toArray()
+    const seqC = rawJoinSequence(docC).toArray()
+    expect(seqB).toEqual(seqC)
+    expect(seqB[0]).toBe('peer-A')
+    expect([...seqB.slice(1)].sort()).toEqual(['peer-B', 'peer-C'])
   })
 
   test('a peer joining after sync does not duplicate an already-synced entry', () => {
     const docA = new Y.Doc()
     const docB = new Y.Doc()
 
-    ensureJoined(docA, 'peer-A')
+    ensureJoined(docA, 'peer-A', { isCreator: true })
     Y.applyUpdate(docB, Y.encodeStateAsUpdate(docA))
 
     // peer-B now sees peer-A already joined; peer-B joins for real, and
@@ -91,7 +134,7 @@ describe('ensureJoined — concurrent joins across two replicas', () => {
 describe('compareAuthority / isAuthoritative', () => {
   test('earlier joiner is authoritative over a later joiner', () => {
     const ydoc = new Y.Doc()
-    ensureJoined(ydoc, 'peer-A')
+    ensureJoined(ydoc, 'peer-A', { isCreator: true })
     ensureJoined(ydoc, 'peer-B')
 
     expect(compareAuthority(ydoc, 'peer-A', 'peer-B')).toBeLessThan(0)
@@ -102,14 +145,14 @@ describe('compareAuthority / isAuthoritative', () => {
 
   test('comparing an id against itself is 0 and not authoritative over itself', () => {
     const ydoc = new Y.Doc()
-    ensureJoined(ydoc, 'peer-A')
+    ensureJoined(ydoc, 'peer-A', { isCreator: true })
     expect(compareAuthority(ydoc, 'peer-A', 'peer-A')).toBe(0)
     expect(isAuthoritative(ydoc, 'peer-A', 'peer-A')).toBe(false)
   })
 
   test('a known peer always outranks an unrecorded one', () => {
     const ydoc = new Y.Doc()
-    ensureJoined(ydoc, 'peer-A')
+    ensureJoined(ydoc, 'peer-A', { isCreator: true })
     expect(isAuthoritative(ydoc, 'peer-A', 'peer-ghost')).toBe(true)
     expect(isAuthoritative(ydoc, 'peer-ghost', 'peer-A')).toBe(false)
   })
@@ -123,7 +166,7 @@ describe('compareAuthority / isAuthoritative', () => {
 describe('resetJoinSequence', () => {
   test('clears every existing entry and leaves only the given ids, in order', () => {
     const ydoc = new Y.Doc()
-    ensureJoined(ydoc, 'peer-A')
+    ensureJoined(ydoc, 'peer-A', { isCreator: true })
     ensureJoined(ydoc, 'peer-B')
     ensureJoined(ydoc, 'peer-C')
 
@@ -134,7 +177,7 @@ describe('resetJoinSequence', () => {
 
   test('accepts more than one id, in the order given', () => {
     const ydoc = new Y.Doc()
-    ensureJoined(ydoc, 'peer-A')
+    ensureJoined(ydoc, 'peer-A', { isCreator: true })
     resetJoinSequence(ydoc, ['peer-C', 'peer-B'])
     expect(rawJoinSequence(ydoc).toArray()).toEqual(['peer-C', 'peer-B'])
   })
@@ -147,7 +190,7 @@ describe('resetJoinSequence', () => {
 
   test('the sole surviving entry is authoritative over everyone else post-reset', () => {
     const ydoc = new Y.Doc()
-    ensureJoined(ydoc, 'peer-A')
+    ensureJoined(ydoc, 'peer-A', { isCreator: true })
     ensureJoined(ydoc, 'peer-B')
     resetJoinSequence(ydoc, ['peer-B'])
 


### PR DESCRIPTION
ensureJoined ran immediately after the local IndexedDB replay landed, but before any WebRTC sync — so a joiner's local joinSequence was still empty when it inserted itself, racing the creator's already-committed (but not-yet-synced) entry as a concurrent Y.Array insert. Yjs's CRDT tie-break for that race doesn't honor real-world join order, so the joiner could sort ahead of the creator, contradicting the documented "bias toward the creator" (CONCURRENCY_AND_BRANCHING.md).

ensureJoined now takes the same isCreator signal index.html already computes for the op log's genesis checkpoint (toys.js's projectLayer, same fix pattern): a joiner facing an empty joinSequence defers and retries once the array actually changes, instead of inserting blind.