### PR TITLE
Fix isCreator detection for a typed/pasted #tableId

### DIFF
--- a/src/home.html
+++ b/src/home.html
@@ -902,7 +902,7 @@ const rowSvgReady = new Map(
 // Uses storage.js import machinery to read svg contents from a sampler
 // template into the live doc getYDoc() hands back
 async function seedTable(tableId, sampleSvgEl) {
-  const ydoc = await tables.getYDoc(tableId);
+  const { ydoc } = await tables.getYDoc(tableId);
   ydoc.transact(() => {
     // Sampler templates carry a decorative rotation on each toy <g> for
     // homepage visual flair — not part of the canonical seeded document.
@@ -946,13 +946,22 @@ function launchRipple(cx, cy, svgEl) {
 
   // Seed the table into IndexedDB, then navigate once done (or after the
   // ripple animation completes, whichever is later).
+  //
+  // ?mint=1 tells index.html this table id was just minted here, not
+  // pasted/typed in from somewhere else — seedTable already stamps this
+  // table's docId via getYDoc before navigating, so by the time index.html
+  // loads it, "have I already got this table locally" alone can no longer
+  // tell "I just made this" apart from "I'm genuinely revisiting it" (see
+  // join_intent.js's module comment). Without the marker, index.html would
+  // wrongly treat this as an existing table and never join its own
+  // joinSequence.
   const seedDone    = seedTable(tableId, svgEl);
   const rippleDone  = new Promise(r => setTimeout(r, 520));
   Promise.all([seedDone, rippleDone]).then(() => {
-    window.location.href = `index.html#${tableId}`;
+    window.location.href = `index.html?mint=1#${tableId}`;
   }).catch(err => {
     console.error('togetherness: table seed failed', err);
-    window.location.href = `index.html#${tableId}`;
+    window.location.href = `index.html?mint=1#${tableId}`;
   });
 }
 

--- a/src/home.html
+++ b/src/home.html
@@ -903,12 +903,22 @@ const rowSvgReady = new Map(
 // template into the live doc getYDoc() hands back
 async function seedTable(tableId, sampleSvgEl) {
   const { ydoc } = await tables.getYDoc(tableId);
+  const { localId: myId } = getIdentity();
   ydoc.transact(() => {
     // Sampler templates carry a decorative rotation on each toy <g> for
     // homepage visual flair — not part of the canonical seeded document.
-    const { localId: myId } = getIdentity();
     populateFromSvgDoc(sampleSvgEl, ydoc, { stripToyDecorative: true, asNewTable: true, authorId: myId });
   });
+
+  // Join the authority ordering here, not in index.html: this table id was
+  // just generated a moment ago (tables.generateTableId, above), so nobody
+  // else can possibly know it yet — genuinely unambiguous, unlike a
+  // typed/pasted #tableId index.html has never seen (see
+  // join_intent.js's module comment). Doing it here means index.html's own
+  // boot logic never needs a special "I was just created" case at all: by
+  // the time it loads this table, isCreator is just a fact already sitting
+  // in the doc (see index.html's isCreator derivation).
+  tables.ensureJoined(ydoc, myId, { isCreator: true });
 
   // ensure the doc is synced to Indexeddb before we navigate away
   await tables.openTablePersistence(tableId, ydoc);
@@ -945,23 +955,17 @@ function launchRipple(cx, cy, svgEl) {
   tables.touchTableRecord(tableId);
 
   // Seed the table into IndexedDB, then navigate once done (or after the
-  // ripple animation completes, whichever is later).
-  //
-  // ?mint=1 tells index.html this table id was just minted here, not
-  // pasted/typed in from somewhere else — seedTable already stamps this
-  // table's docId via getYDoc before navigating, so by the time index.html
-  // loads it, "have I already got this table locally" alone can no longer
-  // tell "I just made this" apart from "I'm genuinely revisiting it" (see
-  // join_intent.js's module comment). Without the marker, index.html would
-  // wrongly treat this as an existing table and never join its own
-  // joinSequence.
+  // ripple animation completes, whichever is later). seedTable already
+  // joined the authority ordering as part of seeding, so index.html's own
+  // boot logic just sees an already-known table with this browser's id
+  // first in its joinSequence — no marker needed.
   const seedDone    = seedTable(tableId, svgEl);
   const rippleDone  = new Promise(r => setTimeout(r, 520));
   Promise.all([seedDone, rippleDone]).then(() => {
-    window.location.href = `index.html?mint=1#${tableId}`;
+    window.location.href = `index.html#${tableId}`;
   }).catch(err => {
     console.error('togetherness: table seed failed', err);
-    window.location.href = `index.html?mint=1#${tableId}`;
+    window.location.href = `index.html#${tableId}`;
   });
 }
 

--- a/src/home.html
+++ b/src/home.html
@@ -899,8 +899,6 @@ const rowSvgReady = new Map(
 );
 
 // ── Seed a new table from a sample SVG into IndexedDB ────────────────────────
-// Uses storage.js import machinery to read svg contents from a sampler
-// template into the live doc getYDoc() hands back
 async function seedTable(tableId, sampleSvgEl) {
   const { ydoc } = await tables.getYDoc(tableId);
   const { localId: myId } = getIdentity();
@@ -910,14 +908,8 @@ async function seedTable(tableId, sampleSvgEl) {
     populateFromSvgDoc(sampleSvgEl, ydoc, { stripToyDecorative: true, asNewTable: true, authorId: myId });
   });
 
-  // Join the authority ordering here, not in index.html: this table id was
-  // just generated a moment ago (tables.generateTableId, above), so nobody
-  // else can possibly know it yet — genuinely unambiguous, unlike a
-  // typed/pasted #tableId index.html has never seen (see
-  // join_intent.js's module comment). Doing it here means index.html's own
-  // boot logic never needs a special "I was just created" case at all: by
-  // the time it loads this table, isCreator is just a fact already sitting
-  // in the doc (see index.html's isCreator derivation).
+  // Add myself to the joinSequence. Doing it here means index.html's
+  // boot logic will find the table and know "me" is the creator.
   tables.ensureJoined(ydoc, myId, { isCreator: true });
 
   // ensure the doc is synced to Indexeddb before we navigate away
@@ -955,10 +947,7 @@ function launchRipple(cx, cy, svgEl) {
   tables.touchTableRecord(tableId);
 
   // Seed the table into IndexedDB, then navigate once done (or after the
-  // ripple animation completes, whichever is later). seedTable already
-  // joined the authority ordering as part of seeding, so index.html's own
-  // boot logic just sees an already-known table with this browser's id
-  // first in its joinSequence — no marker needed.
+  // ripple animation completes, whichever is later)
   const seedDone    = seedTable(tableId, svgEl);
   const rippleDone  = new Promise(r => setTimeout(r, 520));
   Promise.all([seedDone, rippleDone]).then(() => {

--- a/src/index.html
+++ b/src/index.html
@@ -264,8 +264,7 @@ App.addLog('loaded from indexeddb', 'local');
 tables.touchTableRecord(tableId);
 
 // ── WebRTC  ─────────────────────────────────────────────────────────────────
-// Constructed before isCreator is decided: the ambiguous case below needs
-// a live provider to probe, and the unambiguous cases need one anyway.
+// Must be constructed before isCreator is decided
 const signalingUrls = resolveSignalingServers();
 Trace.net('signaling', `signaling servers: ${signalingUrls.join(', ')}`, {
   urls:               signalingUrls,
@@ -280,27 +279,19 @@ Trace.net('provider', 'WebrtcProvider constructed — handshakes begin', { room:
 const awareness    = provider.awareness;
 awareness.setLocalState({ id: myId, color: myGrad.c1, grad: myGrad, cursor: null, selection: null });
 
-// isCreator: !location.hash alone isn't enough — a table id can also
-// arrive already-known locally, where it's just a fact already sitting in
-// the doc (home.html's "Start Here" and its fork/duplicate flows both
-// join the authority ordering as part of seeding, before ever navigating
-// here — see home.html's seedTable), or genuinely ambiguous (a
-// typed/pasted link this browser has never seen). Only that last case
-// needs to actually ask — resolveJoinIntent probes the network and shows
-// a dialog (see join_intent.js / ui_join_dialog.js / ui.js).
 let isCreator;
 if (noHash) {
   isCreator = true;
 } else if (!wasFresh) {
   isCreator = tables.getJoinSequenceArray(ydoc)[0] === myId;
 } else {
+  // resolveJoinIntent probes the network and shows a dialog
   isCreator = await resolveJoinIntent({ provider, tableId, ydoc });
 }
 
-// Join the authority ordering only now that isCreator is settled —
-// ensureJoined's guard needs to know whether an empty joinSequence means
-// "brand new table" or "haven't synced with the creator yet" (see
-// tables.js's ensureJoined).
+// Must go after isCreator is settled -- ensureJoined's guard needs to know
+// whether an empty joinSequence means
+// "brand new table" or "haven't synced with the creator yet"
 tables.ensureJoined(ydoc, myId, { isCreator });
 
 // ── Boot ────────────────────────────────────────────────────────────────────

--- a/src/index.html
+++ b/src/index.html
@@ -163,6 +163,21 @@
   </div>
 </div>
 
+<!-- ── Join-intent dialog (blocking — shown only while a typed/pasted
+     #tableId this browser has never seen before is being probed; see
+     join_dialog.js's resolveJoinIntent) ─────────────────────────────── -->
+<div id="joinDialogScrim" class="dialog-scrim" aria-hidden="true"></div>
+<div id="joinDialog" class="dialog" role="alertdialog" aria-modal="true"
+     aria-labelledby="joinDialogTitle" aria-hidden="true">
+  <div class="dialog-head">
+    <h2 id="joinDialogTitle">Connecting…</h2>
+  </div>
+  <div class="dialog-body" id="joinDialogBody">
+    <p>Looking for this table on the network…</p>
+  </div>
+  <div class="dialog-actions" id="joinDialogActions"></div>
+</div>
+
 <!-- ── Status bar (retained from old index.html for debugging) ────────────── -->
 <div id="statusBar" style="position:fixed;top:0;left:50%;transform:translateX(-50%);
      font-size:11px;color:var(--text-3);pointer-events:none;z-index:100;
@@ -192,6 +207,7 @@ import * as UI                  from './ui.js';
 import { getIdentity }          from './user.js';
 import { dragPlaceholderFilterSVG, snapPointGradientSVG, localActionFilterSVG, glowFilterSVG }  from './defs.js';
 import { tablesAPI as tables } from './tables.js';
+import { resolveJoinIntent }    from './join_dialog.js';
 import { resolveSignalingServers, getStoredSignalingServer, getStoredFallbackSignalingServer } from './signaling.js';
 import * as Trace                  from './trace.js';
 
@@ -220,14 +236,22 @@ Trace.boot('identity', `local identity resolved: ${myDisplayName}`,
 
 // ── Table  ──────────────────────────────────────────────────────────────────
 let tableId = location.hash.slice(1);
-const isCreator = !tableId;
-if (isCreator) {
+const noHash = !tableId;
+
+// ?mint=1 marks a hash that index.html itself just set a moment ago (see
+// home.html's launchRipple) — a *known* fresh table, not a pasted/typed
+// link to an unknown one. Scrubbed from the URL immediately so it never
+// ends up in a bookmark or a shared link.
+const mintedHere = new URLSearchParams(location.search).get('mint') === '1';
+if (mintedHere) history.replaceState(null, '', location.pathname + location.hash);
+
+if (noHash) {
   tableId = tables.generateTableId(myDisplayName);
   location.hash = tableId;
 }
 document.getElementById('tableLabel').textContent = tableId;
-Trace.boot('table-id', isCreator ? `minted a new table: ${tableId}` : `joining table: ${tableId}`,
-  { tableId, isCreator, hash: location.hash });
+Trace.boot('table-id', noHash ? `minted a new table: ${tableId}` : `joining table: ${tableId}`,
+  { tableId, noHash, mintedHere, hash: location.hash });
 
 // Leave this table and join/create whatever table the hash names next —
 // a peer editing the URL bar, browser back/forward, or a same-page link to
@@ -242,18 +266,13 @@ window.addEventListener('hashchange', () => {
   location.reload();
 });
 
-const ydoc  = await tables.getYDoc(tableId);
+const { ydoc, wasFresh } = await tables.getYDoc(tableId);
 App.addLog('loaded from indexeddb', 'local');
 tables.touchTableRecord(tableId);
 
-// Join the authority ordering only now that the local IndexedDB replay has
-// landed — ensureJoined's guard needs to see this table's *existing*
-// joinSequence. isCreator tells it whether an empty joinSequence means
-// "brand new table" or "haven't synced with the creator yet" (see
-// tables.js's ensureJoined).
-tables.ensureJoined(ydoc, myId, { isCreator });
-
 // ── WebRTC  ─────────────────────────────────────────────────────────────────
+// Constructed before isCreator is decided: the ambiguous case below needs
+// a live provider to probe, and the unambiguous cases need one anyway.
 const signalingUrls = resolveSignalingServers();
 Trace.net('signaling', `signaling servers: ${signalingUrls.join(', ')}`, {
   urls:               signalingUrls,
@@ -267,6 +286,28 @@ const provider     = new WebrtcProvider(tableId, ydoc, { signaling: signalingUrl
 Trace.net('provider', 'WebrtcProvider constructed — handshakes begin', { room: tableId });
 const awareness    = provider.awareness;
 awareness.setLocalState({ id: myId, color: myGrad.c1, grad: myGrad, cursor: null, selection: null });
+
+// isCreator: !location.hash alone isn't enough — a table id can also
+// arrive already-known locally (a returning visit or a fork, where
+// ensureJoined is moot either way), freshly minted by home.html's "Start
+// Here" (mintedHere), or genuinely ambiguous (a typed/pasted link this
+// browser has never seen). Only that last case needs to actually ask —
+// resolveJoinIntent probes the network and shows a dialog (see
+// join_intent.js / join_dialog.js / ui.js).
+let isCreator;
+if (noHash || mintedHere) {
+  isCreator = true;
+} else if (!wasFresh) {
+  isCreator = false;
+} else {
+  isCreator = await resolveJoinIntent({ provider, tableId, ydoc });
+}
+
+// Join the authority ordering only now that isCreator is settled —
+// ensureJoined's guard needs to know whether an empty joinSequence means
+// "brand new table" or "haven't synced with the creator yet" (see
+// tables.js's ensureJoined).
+tables.ensureJoined(ydoc, myId, { isCreator });
 
 // ── Boot ────────────────────────────────────────────────────────────────────
 boot({ ydoc, awareness, provider, myId, myGrad, tableId, isCreator, displayName: myDisplayName,

--- a/src/index.html
+++ b/src/index.html
@@ -165,7 +165,7 @@
 
 <!-- ── Join-intent dialog (blocking — shown only while a typed/pasted
      #tableId this browser has never seen before is being probed; see
-     join_dialog.js's resolveJoinIntent) ─────────────────────────────── -->
+     ui_join_dialog.js's resolveJoinIntent) ───────────────────────────── -->
 <div id="joinDialogScrim" class="dialog-scrim" aria-hidden="true"></div>
 <div id="joinDialog" class="dialog" role="alertdialog" aria-modal="true"
      aria-labelledby="joinDialogTitle" aria-hidden="true">
@@ -207,7 +207,7 @@ import * as UI                  from './ui.js';
 import { getIdentity }          from './user.js';
 import { dragPlaceholderFilterSVG, snapPointGradientSVG, localActionFilterSVG, glowFilterSVG }  from './defs.js';
 import { tablesAPI as tables } from './tables.js';
-import { resolveJoinIntent }    from './join_dialog.js';
+import { resolveJoinIntent }    from './ui_join_dialog.js';
 import { resolveSignalingServers, getStoredSignalingServer, getStoredFallbackSignalingServer } from './signaling.js';
 import * as Trace                  from './trace.js';
 
@@ -287,7 +287,7 @@ awareness.setLocalState({ id: myId, color: myGrad.c1, grad: myGrad, cursor: null
 // here — see home.html's seedTable), or genuinely ambiguous (a
 // typed/pasted link this browser has never seen). Only that last case
 // needs to actually ask — resolveJoinIntent probes the network and shows
-// a dialog (see join_intent.js / join_dialog.js / ui.js).
+// a dialog (see join_intent.js / ui_join_dialog.js / ui.js).
 let isCreator;
 if (noHash) {
   isCreator = true;

--- a/src/index.html
+++ b/src/index.html
@@ -238,20 +238,13 @@ Trace.boot('identity', `local identity resolved: ${myDisplayName}`,
 let tableId = location.hash.slice(1);
 const noHash = !tableId;
 
-// ?mint=1 marks a hash that index.html itself just set a moment ago (see
-// home.html's launchRipple) — a *known* fresh table, not a pasted/typed
-// link to an unknown one. Scrubbed from the URL immediately so it never
-// ends up in a bookmark or a shared link.
-const mintedHere = new URLSearchParams(location.search).get('mint') === '1';
-if (mintedHere) history.replaceState(null, '', location.pathname + location.hash);
-
 if (noHash) {
   tableId = tables.generateTableId(myDisplayName);
   location.hash = tableId;
 }
 document.getElementById('tableLabel').textContent = tableId;
 Trace.boot('table-id', noHash ? `minted a new table: ${tableId}` : `joining table: ${tableId}`,
-  { tableId, noHash, mintedHere, hash: location.hash });
+  { tableId, noHash, hash: location.hash });
 
 // Leave this table and join/create whatever table the hash names next —
 // a peer editing the URL bar, browser back/forward, or a same-page link to
@@ -288,17 +281,18 @@ const awareness    = provider.awareness;
 awareness.setLocalState({ id: myId, color: myGrad.c1, grad: myGrad, cursor: null, selection: null });
 
 // isCreator: !location.hash alone isn't enough — a table id can also
-// arrive already-known locally (a returning visit or a fork, where
-// ensureJoined is moot either way), freshly minted by home.html's "Start
-// Here" (mintedHere), or genuinely ambiguous (a typed/pasted link this
-// browser has never seen). Only that last case needs to actually ask —
-// resolveJoinIntent probes the network and shows a dialog (see
-// join_intent.js / join_dialog.js / ui.js).
+// arrive already-known locally, where it's just a fact already sitting in
+// the doc (home.html's "Start Here" and its fork/duplicate flows both
+// join the authority ordering as part of seeding, before ever navigating
+// here — see home.html's seedTable), or genuinely ambiguous (a
+// typed/pasted link this browser has never seen). Only that last case
+// needs to actually ask — resolveJoinIntent probes the network and shows
+// a dialog (see join_intent.js / join_dialog.js / ui.js).
 let isCreator;
-if (noHash || mintedHere) {
+if (noHash) {
   isCreator = true;
 } else if (!wasFresh) {
-  isCreator = false;
+  isCreator = tables.getJoinSequenceArray(ydoc)[0] === myId;
 } else {
   isCreator = await resolveJoinIntent({ provider, tableId, ydoc });
 }

--- a/src/join_dialog.js
+++ b/src/join_dialog.js
@@ -1,0 +1,40 @@
+/**
+ * join_dialog.js — turns join_intent.js's network probe into the actual
+ * "is this session a table's creator?" decision, driving the join-intent
+ * dialog (ui.js's showJoinDialogConnecting/showJoinDialogPrompt/
+ * hideJoinDialog).
+ *
+ * Lives between index.html (which has the live provider/ydoc) and ui.js
+ * (which deliberately knows nothing about Yjs/providers — see ui.js's own
+ * module comment). This module is the one place allowed to hold both.
+ */
+import { watchTableProbe } from './join_intent.js';
+import { tablesAPI as tables } from './tables.js';
+import * as UI from './ui.js';
+
+/**
+ * Resolves to true if this session should proceed as the table's
+ * creator, false if it should proceed as a joiner — only ever called for
+ * a #tableId this browser has never seen before (index.html's caller
+ * already handles the unambiguous cases without a dialog).
+ */
+export function resolveJoinIntent({ provider, tableId, ydoc }) {
+  UI.showJoinDialogConnecting();
+  return new Promise(resolve => {
+    const finish = (isCreator) => {
+      UI.hideJoinDialog();
+      resolve(isCreator);
+    };
+    watchTableProbe(provider, {
+      onPhase(phase) {
+        if (phase === 'unreachable') {
+          UI.showJoinDialogPrompt('unreachable', undefined, () => finish(true));
+        } else if (phase === 'not-found') {
+          UI.showJoinDialogPrompt('not-found', tableId, () => finish(true));
+        } else if (phase === 'found') {
+          UI.showJoinDialogPrompt('found', tables.getJoinSequenceArray(ydoc), () => finish(false));
+        }
+      },
+    });
+  });
+}

--- a/src/join_intent.js
+++ b/src/join_intent.js
@@ -1,0 +1,117 @@
+/**
+ * join_intent.js — deciding whether this peer is a table's creator when
+ * that's genuinely ambiguous (a typed/pasted `#tableId` this browser has
+ * never seen before).
+ *
+ * A table's existence can't be queried directly: the signaling server is
+ * stock y-webrtc-signaling (docker/signaling.Dockerfile), with no
+ * room-roster API. The only signal available is empirical — did a peer's
+ * WebRTC handshake actually complete — so this is a race between two
+ * timeouts, not a lookup. No DOM, no ydoc: index.html/ui.js own turning
+ * the outcome into a dialog and an isCreator decision.
+ */
+
+export const SIGNALING_TIMEOUT_MS = 6000
+export const PEER_TIMEOUT_MS      = 5000
+
+const SIGNALING_TIMEOUT_KEY = 'tt_join_signaling_timeout_ms'
+const PEER_TIMEOUT_KEY      = 'tt_join_peer_timeout_ms'
+
+function resolveTimeoutMs(key, fallback) {
+  const stored = Number(localStorage.getItem(key))
+  return Number.isFinite(stored) && stored > 0 ? stored : fallback
+}
+
+/** localStorage override (tests), else SIGNALING_TIMEOUT_MS. */
+export function resolveSignalingTimeoutMs() {
+  return resolveTimeoutMs(SIGNALING_TIMEOUT_KEY, SIGNALING_TIMEOUT_MS)
+}
+
+/** localStorage override (tests), else PEER_TIMEOUT_MS. */
+export function resolvePeerTimeoutMs() {
+  return resolveTimeoutMs(PEER_TIMEOUT_KEY, PEER_TIMEOUT_MS)
+}
+
+/**
+ * Watches a live WebrtcProvider-shaped object and calls onPhase exactly
+ * once with one of:
+ *
+ *   'unreachable' — no signaling connection came up within signalingTimeoutMs
+ *   'found'       — signaling connected, and a peer fully synced in
+ *                   (provider's 'synced' event, synced: true) within
+ *                   peerTimeoutMs of that
+ *   'not-found'   — signaling connected, but no peer synced in within
+ *                   peerTimeoutMs
+ *
+ * provider only needs: .signalingConns (array of {connected, on, off}),
+ * and .on/.off('synced', cb) where cb receives {synced: boolean} — exactly
+ * what y-webrtc's WebrtcProvider and its per-URL SignalingConn expose.
+ * 'synced' also fires with synced:false (e.g. a peer disconnecting), which
+ * must not be mistaken for 'found'.
+ *
+ * If a signaling connection is already up when this is called (y-webrtc
+ * keeps a module-level, URL-keyed connection pool, so a second table
+ * opened in the same tab often reuses an already-connected socket), skips
+ * straight to the peer-wait phase.
+ *
+ * Self-unsubscribes everything before calling onPhase, so it only ever
+ * fires once — callers don't need to tear anything down themselves.
+ */
+export function watchTableProbe(provider, {
+  onPhase,
+  setTimer = (fn, ms) => setTimeout(fn, ms),
+  clearTimer = (id) => clearTimeout(id),
+  signalingTimeoutMs = resolveSignalingTimeoutMs(),
+  peerTimeoutMs = resolvePeerTimeoutMs(),
+} = {}) {
+  let settled = false
+  let signalingTimer = null
+  let peerTimer = null
+
+  const onSynced = ({ synced }) => { if (synced) finish('found') }
+
+  // Stops watching for a signaling connection specifically — called both
+  // when we move on to the peer-wait phase (no longer relevant once one
+  // conn is up) and as part of full cleanup on the terminal unreachable
+  // phase. Safe to call more than once.
+  const stopWatchingSignaling = () => {
+    clearTimer(signalingTimer)
+    for (const conn of provider.signalingConns) conn.off('connect', onSignalingConnected)
+  }
+
+  const cleanup = () => {
+    stopWatchingSignaling()
+    clearTimer(peerTimer)
+    provider.off('synced', onSynced)
+  }
+
+  function finish(phase) {
+    if (settled) return
+    settled = true
+    cleanup()
+    onPhase(phase)
+  }
+
+  function beginPeerWait() {
+    stopWatchingSignaling()
+    provider.on('synced', onSynced)
+    peerTimer = setTimer(() => finish('not-found'), peerTimeoutMs)
+  }
+
+  function onSignalingConnected() {
+    beginPeerWait()
+  }
+
+  if (!provider.signalingConns.length) {
+    finish('unreachable')
+    return
+  }
+
+  if (provider.signalingConns.some(conn => conn.connected)) {
+    beginPeerWait()
+    return
+  }
+
+  for (const conn of provider.signalingConns) conn.on('connect', onSignalingConnected)
+  signalingTimer = setTimer(() => finish('unreachable'), signalingTimeoutMs)
+}

--- a/src/tables.js
+++ b/src/tables.js
@@ -260,11 +260,7 @@ async function openTablePersistence(tableId, ydoc) {
  * initTableDoc() before returning. Callers never need to check themselves
  *
  * Returns { ydoc, wasFresh }: wasFresh is true iff this browser had never
- * seen this tableId before this call (no docId was found, so one was just
- * stamped). index.html uses this to tell a genuinely-new table apart from
- * one it's simply revisiting — see join_intent.js's module comment for
- * why that distinction can't be made any other way from inside the doc
- * itself.
+ * seen this tableId before this call
  */
 async function getYDoc(tableId) {
   const ydoc = makeDoc();

--- a/src/tables.js
+++ b/src/tables.js
@@ -258,16 +258,24 @@ async function openTablePersistence(tableId, ydoc) {
  *
  * If the synced doc turns out to have no docId yet, stamps it via
  * initTableDoc() before returning. Callers never need to check themselves
+ *
+ * Returns { ydoc, wasFresh }: wasFresh is true iff this browser had never
+ * seen this tableId before this call (no docId was found, so one was just
+ * stamped). index.html uses this to tell a genuinely-new table apart from
+ * one it's simply revisiting — see join_intent.js's module comment for
+ * why that distinction can't be made any other way from inside the doc
+ * itself.
  */
 async function getYDoc(tableId) {
   const ydoc = makeDoc();
   await openTablePersistence(tableId, ydoc);
-  if (!ydoc.getMap('meta').get('docId')) {
+  const wasFresh = !ydoc.getMap('meta').get('docId');
+  if (wasFresh) {
     Trace.boot('table-init', `stamping a fresh document for "${tableId}"`,
       { tableId, schemaVersion: CURRENT_SCHEMA });
     initTableDoc(ydoc, tableId);
   }
-  return ydoc;
+  return { ydoc, wasFresh };
 }
 
 // ── 'tt_tables' registry (recently-visited tables) ──────────────────────

--- a/src/ui.js
+++ b/src/ui.js
@@ -838,7 +838,7 @@ export function branchDialogKeepWorking() {
 // typed/pasted #tableId it's never seen before (see join_intent.js's
 // module comment for why that can only be settled by probing the
 // network). Purely presentational: no Yjs, no provider, no tables.js — the
-// caller (a new join_dialog.js, which owns the actual network probe) hands
+// caller (a new ui_join_dialog.js, which owns the actual network probe) hands
 // in plain strings/arrays and a callback, same contract as every other
 // exported render function in this file.
 //

--- a/src/ui.js
+++ b/src/ui.js
@@ -832,6 +832,90 @@ export function branchDialogKeepWorking() {
   location.reload();
 }
 
+// -- Join-intent dialog ---------------------------------------------------
+// Blocking (every viewport, same as the branch dialog above) — shown while
+// index.html is deciding whether this session is a table's creator, for a
+// typed/pasted #tableId it's never seen before (see join_intent.js's
+// module comment for why that can only be settled by probing the
+// network). Purely presentational: no Yjs, no provider, no tables.js — the
+// caller (a new join_dialog.js, which owns the actual network probe) hands
+// in plain strings/arrays and a callback, same contract as every other
+// exported render function in this file.
+//
+// tableId and peer ids both ultimately come from outside this browser (a
+// pasted link; another peer's synced joinSequence) — escaped via
+// debug_panel.js's esc(), the same convention that panel already uses for
+// the same untrusted values.
+
+export function showJoinDialogConnecting() {
+  const title = $('#joinDialogTitle');
+  if (title) title.textContent = 'Connecting…';
+  const body = $('#joinDialogBody');
+  if (body) body.innerHTML = '<p>Looking for this table on the network…</p>';
+  const actions = $('#joinDialogActions');
+  if (actions) actions.innerHTML = '';
+  $('#joinDialogScrim')?.classList.add('open');
+  $('#joinDialogScrim')?.setAttribute('aria-hidden', 'false');
+  $('#joinDialog')?.classList.add('open');
+  $('#joinDialog')?.setAttribute('aria-hidden', 'false');
+}
+
+const JOIN_DIALOG_COPY = {
+  unreachable: () => ({
+    title: "Can't reach the network",
+    body: `<p>We couldn't reach the signaling server, so we can't tell
+      whether anyone else is already using this table.</p>`,
+    button: 'Proceed offline',
+  }),
+  'not-found': (tableId) => ({
+    title: 'Create this table?',
+    body: `<p>Nobody else is here yet. This starts
+      <strong>${Debug.esc(tableId)}</strong> as a brand-new table.</p>`,
+    button: 'Create this table',
+  }),
+  found: (peerIds) => ({
+    title: 'Join this table?',
+    body: `
+      <p>This table already has ${peerIds.length} member${peerIds.length === 1 ? '' : 's'}:</p>
+      <div class="dbg-join-ladder">${
+        peerIds.map(id => `<code class="dbg-id">${Debug.esc(id)}</code>`).join('')
+      }</div>`,
+    button: 'Join this table',
+  }),
+};
+
+/**
+ * phase: 'unreachable' | 'not-found' | 'found', matching join_intent.js's
+ * watchTableProbe outcomes. data is the phase-specific payload
+ * (undefined, the tableId string, or the peer-id array, respectively).
+ * onConfirm fires when the dialog's one action button is clicked — the
+ * caller decides what that means (proceed as creator or as joiner).
+ */
+export function showJoinDialogPrompt(phase, data, onConfirm) {
+  const spec = JOIN_DIALOG_COPY[phase]?.(data);
+  if (!spec) return;
+  const title = $('#joinDialogTitle');
+  if (title) title.textContent = spec.title;
+  const body = $('#joinDialogBody');
+  if (body) body.innerHTML = spec.body;
+  const actions = $('#joinDialogActions');
+  if (actions) {
+    actions.innerHTML = '';
+    const btn = document.createElement('button');
+    btn.className = 'dialog-btn dialog-btn-primary';
+    btn.textContent = spec.button;
+    btn.addEventListener('click', onConfirm, { once: true });
+    actions.appendChild(btn);
+  }
+}
+
+export function hideJoinDialog() {
+  $('#joinDialogScrim')?.classList.remove('open');
+  $('#joinDialogScrim')?.setAttribute('aria-hidden', 'true');
+  $('#joinDialog')?.classList.remove('open');
+  $('#joinDialog')?.setAttribute('aria-hidden', 'true');
+}
+
 // -- Data gatherers (impure) ---------------------------------------------------
 function gatherToolsData() {
   const layer = App.getActiveLayer();

--- a/src/ui_join_dialog.js
+++ b/src/ui_join_dialog.js
@@ -1,5 +1,5 @@
 /**
- * join_dialog.js — turns join_intent.js's network probe into the actual
+ * ui_join_dialog.js — turns join_intent.js's network probe into the actual
  * "is this session a table's creator?" decision, driving the join-intent
  * dialog (ui.js's showJoinDialogConnecting/showJoinDialogPrompt/
  * hideJoinDialog).

--- a/tests/e2e/helpers.js
+++ b/tests/e2e/helpers.js
@@ -41,10 +41,45 @@ export async function openAsCreator(page, { appUrl, signalingUrl }) {
   return page.evaluate(() => location.hash.slice(1));
 }
 
-/** Navigate page to an existing room — a real joiner, never a creator. */
+/**
+ * join_intent.js's network-probe timeouts, overridable the same way
+ * seedSignaling overrides the signaling URL — via localStorage, seeded
+ * before any script runs. Only needed by specs that deliberately exercise
+ * the "nobody's here" / "can't reach the network" outcomes quickly;
+ * joinRoom below leaves the real (generous) defaults in place, since a
+ * real joiner's dialog should almost always resolve to "found" well
+ * within them.
+ */
+export async function seedJoinTimeouts(page, { signalingTimeoutMs, peerTimeoutMs } = {}) {
+  await page.addInitScript(({ signalingTimeoutMs, peerTimeoutMs }) => {
+    if (signalingTimeoutMs) localStorage.setItem('tt_join_signaling_timeout_ms', String(signalingTimeoutMs));
+    if (peerTimeoutMs)      localStorage.setItem('tt_join_peer_timeout_ms', String(peerTimeoutMs));
+  }, { signalingTimeoutMs, peerTimeoutMs });
+}
+
+/**
+ * The join-intent dialog's one action button (any of "Join this table" /
+ * "Create this table" / "Proceed offline" — see ui.js's
+ * showJoinDialogPrompt). Callers wait for it themselves (e.g.
+ * `.click({ timeout })`), generously, since the real probe races network
+ * timeouts (join_intent.js's SIGNALING_TIMEOUT_MS + PEER_TIMEOUT_MS).
+ */
+export function joinDialogButton(page) {
+  return page.locator('#joinDialogActions button').first();
+}
+
+/**
+ * Navigate page to an existing room — a real joiner, never a creator.
+ * Always lands on the join-intent dialog first (a fresh browser context
+ * has no local record of the room), so this waits for and confirms
+ * whichever outcome the probe reaches — in practice always "Join this
+ * table", since the creator (already open in another page) is normally
+ * long since connected to signaling by the time this runs.
+ */
 export async function joinRoom(page, room, { appUrl, signalingUrl }) {
   await seedSignaling(page, signalingUrl);
   await page.goto(`${appUrl}/#${room}`);
+  await joinDialogButton(page).click({ timeout: 15000 });
 }
 
 /** openAsCreator + joinRoom, for the common case with nothing in between. */

--- a/tests/e2e/join-dialog.spec.js
+++ b/tests/e2e/join-dialog.spec.js
@@ -22,6 +22,21 @@ async function seedSignalingUrl(page, url) {
   await page.addInitScript((url) => localStorage.setItem('tt_signaling_server', url), url);
 }
 
+/**
+ * Overrides BOTH signaling URLs. signaling.js's defaultFallbackSignalingServer()
+ * only returns '' when location.hostname === 'localhost' — under Docker the
+ * page is served from a container IP, so leaving the fallback at its
+ * default resolves to a real public server, which a Docker test runner
+ * with real network access can actually reach. Tests asserting a truly
+ * unreachable signaling layer need both URLs broken, not just the primary.
+ */
+async function seedUnreachableSignaling(page) {
+  await page.addInitScript(() => {
+    localStorage.setItem('tt_signaling_server', 'ws://127.0.0.1:1');
+    localStorage.setItem('tt_signaling_server_fallback', 'ws://127.0.0.1:1');
+  });
+}
+
 test.describe('join-intent dialog', () => {
   test('no hash: creator, dialog never appears', async ({ page }) => {
     await seedSignalingUrl(page, SIGNALING_URL);
@@ -42,9 +57,10 @@ test.describe('join-intent dialog', () => {
     await expect(row).not.toHaveClass(/loading/, { timeout: 10000 });
     await row.click();
 
-    // serve resolves "index.html" implicitly for "/", so the navigated URL
-    // is just "/#tableId", not "/index.html#tableId".
-    await page.waitForURL(/\/#tt-T-v1-/, { timeout: 10000 });
+    // Different static servers resolve "/" differently — some show a bare
+    // "/#tableId", others "/index.html#tableId" — so match on the hash
+    // alone rather than assuming what precedes it.
+    await page.waitForURL(/#tt-T-v1-/, { timeout: 10000 });
     await expect(page.locator('#tableLabel')).not.toHaveText('', { timeout: 8000 });
     await page.waitForTimeout(300); // give a spurious dialog a chance to open
     await expect(page.locator('#joinDialogScrim')).not.toHaveClass(/open/);
@@ -114,8 +130,9 @@ test.describe('join-intent dialog', () => {
   });
 
   test('signaling unreachable: offline prompt, "Proceed offline" proceeds as creator', async ({ page }) => {
-    // Port 1: nothing listens there, so the WebSocket fails fast.
-    await seedSignalingUrl(page, 'ws://127.0.0.1:1');
+    // Port 1: nothing listens there, so the WebSocket fails fast. Both
+    // primary and fallback need to be broken — see seedUnreachableSignaling.
+    await seedUnreachableSignaling(page);
     await seedJoinTimeouts(page, { signalingTimeoutMs: 1500, peerTimeoutMs: 1500 });
 
     const tableId = 'tt-T-v1-unreachable-' + Date.now();

--- a/tests/e2e/join-dialog.spec.js
+++ b/tests/e2e/join-dialog.spec.js
@@ -1,0 +1,120 @@
+/**
+ * tests/e2e/join-dialog.spec.js
+ *
+ * isCreator used to be just `!location.hash` — too coarse. A typed/pasted
+ * #tableId this browser has never seen before is genuinely ambiguous:
+ * nobody knows without asking the network whether someone else already
+ * created it. join_intent.js/join_dialog.js/ui.js resolve that by probing
+ * the WebRTC signaling handshake and showing a blocking dialog when (and
+ * only when) it's actually ambiguous — see index.html's isCreator
+ * derivation and its comment.
+ *
+ * Run via bin/test_e2e.sandbox.sh (no Docker) or bin/test.sh (Docker).
+ */
+
+import { test, expect, chromium } from '@playwright/test';
+import { openAsCreator, seedJoinTimeouts, joinDialogButton } from './helpers.js';
+
+const APP_URL        = process.env.APP_URL       || 'http://localhost:3000';
+const SIGNALING_URL  = process.env.SIGNALING_URL || 'ws://localhost:4444';
+
+async function seedSignalingUrl(page, url) {
+  await page.addInitScript((url) => localStorage.setItem('tt_signaling_server', url), url);
+}
+
+test.describe('join-intent dialog', () => {
+  test('no hash: creator, dialog never appears', async ({ page }) => {
+    await seedSignalingUrl(page, SIGNALING_URL);
+    await page.goto(`${APP_URL}/`);
+    await page.waitForFunction(() => location.hash.length > 1);
+    await page.waitForTimeout(300); // give a spurious dialog a chance to open
+    await expect(page.locator('#joinDialogScrim')).not.toHaveClass(/open/);
+  });
+
+  test('?mint=1 (home.html\'s Start Here): creator, dialog never appears', async ({ page }) => {
+    await seedSignalingUrl(page, SIGNALING_URL);
+    const tableId = 'tt-T-v1-mint-test-' + Date.now();
+    await page.goto(`${APP_URL}/?mint=1#${tableId}`);
+    await expect(page.locator('#tableLabel')).toHaveText(tableId);
+    await page.waitForTimeout(300);
+    await expect(page.locator('#joinDialogScrim')).not.toHaveClass(/open/);
+
+    // The mint marker is scrubbed from the URL immediately.
+    expect(await page.evaluate(() => location.search)).toBe('');
+
+    await page.evaluate(() => window.UI.openSheet('debug'));
+    const createdHere = page.locator('.dbg-kv:has(.dbg-k:text-is("created here")) .dbg-v');
+    await expect(createdHere).toHaveText('yes');
+  });
+
+  test('returning visit (reload as creator): dialog never appears', async ({ page }) => {
+    const room = await openAsCreator(page, { appUrl: APP_URL, signalingUrl: SIGNALING_URL });
+    await page.reload();
+    await expect(page.locator('#tableLabel')).toHaveText(room);
+    await page.waitForTimeout(300);
+    await expect(page.locator('#joinDialogScrim')).not.toHaveClass(/open/);
+  });
+
+  test('a real joiner sees "Join this table?" listing the creator, and proceeds after confirming', async () => {
+    const browser = await chromium.launch({ executablePath: process.env.PW_CHROME, args: ['--no-sandbox', '--disable-dev-shm-usage'] });
+    const ctx1  = await browser.newContext();
+    const ctx2  = await browser.newContext();
+    const page1 = await ctx1.newPage();
+    const page2 = await ctx2.newPage();
+
+    const room = await openAsCreator(page1, { appUrl: APP_URL, signalingUrl: SIGNALING_URL });
+    await page1.evaluate(() => window.UI.openSheet('debug'));
+    const creatorId = await page1
+      .locator('.dbg-kv:has(.dbg-k:text-is("my peer id")) .dbg-v code')
+      .textContent();
+
+    await seedSignalingUrl(page2, SIGNALING_URL);
+    await page2.goto(`${APP_URL}/#${room}`);
+
+    await expect(page2.locator('#joinDialogTitle')).toHaveText('Join this table?', { timeout: 15000 });
+    await expect(page2.locator('#joinDialogBody')).toContainText(creatorId);
+
+    await joinDialogButton(page2).click();
+
+    await expect(page1.locator('#peerCount')).toHaveText('1', { timeout: 8000 });
+    await expect(page2.locator('#peerCount')).toHaveText('1', { timeout: 8000 });
+
+    await browser.close();
+  });
+
+  test('nobody home: "Create this table?", proceeds as creator', async ({ page }) => {
+    await seedSignalingUrl(page, SIGNALING_URL);
+    await seedJoinTimeouts(page, { signalingTimeoutMs: 2000, peerTimeoutMs: 1500 });
+
+    const tableId = 'tt-T-v1-nobody-home-' + Date.now();
+    await page.goto(`${APP_URL}/#${tableId}`);
+
+    await expect(page.locator('#joinDialogTitle')).toHaveText('Create this table?', { timeout: 8000 });
+    await expect(page.locator('#joinDialogBody')).toContainText(tableId);
+
+    await joinDialogButton(page).click();
+    await expect(page.locator('#joinDialogScrim')).not.toHaveClass(/open/);
+
+    await page.evaluate(() => window.UI.openSheet('debug'));
+    const createdHere = page.locator('.dbg-kv:has(.dbg-k:text-is("created here")) .dbg-v');
+    await expect(createdHere).toHaveText('yes');
+  });
+
+  test('signaling unreachable: offline prompt, "Proceed offline" proceeds as creator', async ({ page }) => {
+    // Port 1: nothing listens there, so the WebSocket fails fast.
+    await seedSignalingUrl(page, 'ws://127.0.0.1:1');
+    await seedJoinTimeouts(page, { signalingTimeoutMs: 1500, peerTimeoutMs: 1500 });
+
+    const tableId = 'tt-T-v1-unreachable-' + Date.now();
+    await page.goto(`${APP_URL}/#${tableId}`);
+
+    await expect(page.locator('#joinDialogTitle')).toHaveText("Can't reach the network", { timeout: 8000 });
+
+    await joinDialogButton(page).click();
+    await expect(page.locator('#joinDialogScrim')).not.toHaveClass(/open/);
+
+    await page.evaluate(() => window.UI.openSheet('debug'));
+    const createdHere = page.locator('.dbg-kv:has(.dbg-k:text-is("created here")) .dbg-v');
+    await expect(createdHere).toHaveText('yes');
+  });
+});

--- a/tests/e2e/join-dialog.spec.js
+++ b/tests/e2e/join-dialog.spec.js
@@ -31,28 +31,41 @@ test.describe('join-intent dialog', () => {
     await expect(page.locator('#joinDialogScrim')).not.toHaveClass(/open/);
   });
 
-  test('?mint=1 (home.html\'s Start Here): creator, dialog never appears', async ({ page }) => {
+  test('home.html\'s "Start Here": creator, dialog never appears', async ({ page }) => {
     await seedSignalingUrl(page, SIGNALING_URL);
-    const tableId = 'tt-T-v1-mint-test-' + Date.now();
-    await page.goto(`${APP_URL}/?mint=1#${tableId}`);
-    await expect(page.locator('#tableLabel')).toHaveText(tableId);
-    await page.waitForTimeout(300);
-    await expect(page.locator('#joinDialogScrim')).not.toHaveClass(/open/);
+    await page.goto(`${APP_URL}/home.html`);
 
-    // The mint marker is scrubbed from the URL immediately.
-    expect(await page.evaluate(() => location.search)).toBe('');
+    // seedTable joins the authority ordering as part of seeding (see
+    // home.html's launchRipple/seedTable) — index.html should never need
+    // to ask anything about a table it just created.
+    const row = page.locator('.sampler-row').first();
+    await expect(row).not.toHaveClass(/loading/, { timeout: 10000 });
+    await row.click();
+
+    // serve resolves "index.html" implicitly for "/", so the navigated URL
+    // is just "/#tableId", not "/index.html#tableId".
+    await page.waitForURL(/\/#tt-T-v1-/, { timeout: 10000 });
+    await expect(page.locator('#tableLabel')).not.toHaveText('', { timeout: 8000 });
+    await page.waitForTimeout(300); // give a spurious dialog a chance to open
+    await expect(page.locator('#joinDialogScrim')).not.toHaveClass(/open/);
 
     await page.evaluate(() => window.UI.openSheet('debug'));
     const createdHere = page.locator('.dbg-kv:has(.dbg-k:text-is("created here")) .dbg-v');
     await expect(createdHere).toHaveText('yes');
   });
 
-  test('returning visit (reload as creator): dialog never appears', async ({ page }) => {
+  test('returning visit (reload as creator): dialog never appears, and "created here" is still accurate', async ({ page }) => {
     const room = await openAsCreator(page, { appUrl: APP_URL, signalingUrl: SIGNALING_URL });
     await page.reload();
     await expect(page.locator('#tableLabel')).toHaveText(room);
     await page.waitForTimeout(300);
     await expect(page.locator('#joinDialogScrim')).not.toHaveClass(/open/);
+
+    // isCreator for an already-known table is derived from joinSequence,
+    // not hardcoded false — a returning creator should still see "yes".
+    await page.evaluate(() => window.UI.openSheet('debug'));
+    const createdHere = page.locator('.dbg-kv:has(.dbg-k:text-is("created here")) .dbg-v');
+    await expect(createdHere).toHaveText('yes');
   });
 
   test('a real joiner sees "Join this table?" listing the creator, and proceeds after confirming', async () => {

--- a/tests/e2e/join-dialog.spec.js
+++ b/tests/e2e/join-dialog.spec.js
@@ -4,7 +4,7 @@
  * isCreator used to be just `!location.hash` — too coarse. A typed/pasted
  * #tableId this browser has never seen before is genuinely ambiguous:
  * nobody knows without asking the network whether someone else already
- * created it. join_intent.js/join_dialog.js/ui.js resolve that by probing
+ * created it. join_intent.js/ui_join_dialog.js/ui.js resolve that by probing
  * the WebRTC signaling handshake and showing a blocking dialog when (and
  * only when) it's actually ambiguous — see index.html's isCreator
  * derivation and its comment.

--- a/tests/unit/join-intent.test.js
+++ b/tests/unit/join-intent.test.js
@@ -1,0 +1,138 @@
+// join_intent.js's watchTableProbe is the actual race-condition logic
+// behind the "is this table's creator already here?" dialog — this test
+// exercises it deterministically with fake timers and a minimal fake
+// WebrtcProvider, the same way tables-authority.test.js covers the
+// ensureJoined race without relying on real network timing.
+
+import { describe, test, expect, vi, beforeEach, afterEach } from 'vitest'
+import { watchTableProbe } from '../../src/join_intent.js'
+
+// A minimal stand-in for y-webrtc's SignalingConn: an event emitter with
+// a `connected` flag, supporting exactly what watchTableProbe uses.
+function fakeConn(connected = false) {
+  const listeners = new Map()
+  return {
+    connected,
+    on(name, fn)  { (listeners.get(name) ?? listeners.set(name, new Set()).get(name)).add(fn) },
+    off(name, fn) { listeners.get(name)?.delete(fn) },
+    emit(name, ...args) { for (const fn of listeners.get(name) ?? []) fn(...args) },
+    listenerCount(name) { return listeners.get(name)?.size ?? 0 },
+  }
+}
+
+// A minimal stand-in for WebrtcProvider: just the 'synced' emitter plus
+// whatever signalingConns array the test wants.
+function fakeProvider(signalingConns) {
+  const listeners = new Map()
+  return {
+    signalingConns,
+    on(name, fn)  { (listeners.get(name) ?? listeners.set(name, new Set()).get(name)).add(fn) },
+    off(name, fn) { listeners.get(name)?.delete(fn) },
+    emit(name, ...args) { for (const fn of listeners.get(name) ?? []) fn(...args) },
+  }
+}
+
+beforeEach(() => vi.useFakeTimers())
+afterEach(() => vi.useRealTimers())
+
+describe('watchTableProbe', () => {
+  test('empty signalingConns is immediately unreachable', () => {
+    const provider = fakeProvider([])
+    const onPhase = vi.fn()
+    watchTableProbe(provider, { onPhase, signalingTimeoutMs: 1000, peerTimeoutMs: 1000 })
+    expect(onPhase).toHaveBeenCalledWith('unreachable')
+  })
+
+  test('no signaling connection within signalingTimeoutMs is unreachable', () => {
+    const conn = fakeConn(false)
+    const provider = fakeProvider([conn])
+    const onPhase = vi.fn()
+    watchTableProbe(provider, { onPhase, signalingTimeoutMs: 1000, peerTimeoutMs: 1000 })
+
+    vi.advanceTimersByTime(999)
+    expect(onPhase).not.toHaveBeenCalled()
+    vi.advanceTimersByTime(1)
+    expect(onPhase).toHaveBeenCalledWith('unreachable')
+  })
+
+  test('already-connected signaling skips straight to the peer-wait phase', () => {
+    const conn = fakeConn(true)
+    const provider = fakeProvider([conn])
+    const onPhase = vi.fn()
+    watchTableProbe(provider, { onPhase, signalingTimeoutMs: 1000, peerTimeoutMs: 500 })
+
+    // Never reaches the signaling timeout — it's already past that phase.
+    vi.advanceTimersByTime(1000)
+    expect(onPhase).toHaveBeenCalledWith('not-found')
+  })
+
+  test('a peer syncing in before peerTimeoutMs is found', () => {
+    const conn = fakeConn(true)
+    const provider = fakeProvider([conn])
+    const onPhase = vi.fn()
+    watchTableProbe(provider, { onPhase, signalingTimeoutMs: 1000, peerTimeoutMs: 1000 })
+
+    vi.advanceTimersByTime(400)
+    provider.emit('synced', { synced: true })
+    expect(onPhase).toHaveBeenCalledWith('found')
+
+    // No further phase after the first.
+    vi.advanceTimersByTime(1000)
+    expect(onPhase).toHaveBeenCalledTimes(1)
+  })
+
+  test('no peer syncing in within peerTimeoutMs is not-found', () => {
+    const conn = fakeConn(true)
+    const provider = fakeProvider([conn])
+    const onPhase = vi.fn()
+    watchTableProbe(provider, { onPhase, signalingTimeoutMs: 1000, peerTimeoutMs: 500 })
+
+    vi.advanceTimersByTime(499)
+    expect(onPhase).not.toHaveBeenCalled()
+    vi.advanceTimersByTime(1)
+    expect(onPhase).toHaveBeenCalledWith('not-found')
+  })
+
+  test('a synced:false event does not count as found', () => {
+    const conn = fakeConn(true)
+    const provider = fakeProvider([conn])
+    const onPhase = vi.fn()
+    watchTableProbe(provider, { onPhase, signalingTimeoutMs: 1000, peerTimeoutMs: 500 })
+
+    provider.emit('synced', { synced: false })
+    expect(onPhase).not.toHaveBeenCalled()
+    vi.advanceTimersByTime(500)
+    expect(onPhase).toHaveBeenCalledWith('not-found')
+  })
+
+  test('signaling connecting late starts the peer-wait clock from that point, not from t=0', () => {
+    const conn = fakeConn(false)
+    const provider = fakeProvider([conn])
+    const onPhase = vi.fn()
+    watchTableProbe(provider, { onPhase, signalingTimeoutMs: 1000, peerTimeoutMs: 500 })
+
+    vi.advanceTimersByTime(900) // right before the signaling timeout
+    conn.emit('connect')
+    vi.advanceTimersByTime(499)
+    expect(onPhase).not.toHaveBeenCalled()
+    vi.advanceTimersByTime(1)
+    expect(onPhase).toHaveBeenCalledWith('not-found')
+  })
+
+  test('two signaling conns: either connecting triggers the transition, and the other listener is torn down', () => {
+    const connA = fakeConn(false)
+    const connB = fakeConn(false)
+    const provider = fakeProvider([connA, connB])
+    const onPhase = vi.fn()
+    watchTableProbe(provider, { onPhase, signalingTimeoutMs: 1000, peerTimeoutMs: 500 })
+
+    connB.emit('connect')
+    expect(connA.listenerCount('connect')).toBe(0)
+
+    // A late connect from A must not double-fire anything.
+    connA.emit('connect')
+    vi.advanceTimersByTime(500)
+    expect(onPhase).toHaveBeenCalledTimes(1)
+    expect(onPhase).toHaveBeenCalledWith('not-found')
+  })
+})


### PR DESCRIPTION
isCreator was just !location.hash, which the ensureJoined fix's isCreator gate exposed as too coarse in two ways:

- home.html's "Start Here" flow hands index.html a URL that already has a hash, so isCreator computed false — and since seedTable never calls ensureJoined, the person who just created the table would defer joining its own joinSequence forever (nobody else is ever coming online for a genuinely new solo table). Real regression, not hypothetical.
- Someone spontaneously typing/pasting a #tableId gets treated as a joiner even though nothing may exist at that id yet, with no signal to the user either way.

isCreator now resolves per four cases: no hash (mint, as before); hash already known in this browser's IndexedDB (moot — ensureJoined no-ops either way); hash minted by home.html's Start Here (new ?mint=1 marker, scrubbed from the URL immediately); or a genuinely unknown hash, which now probes the network (join_intent.js's watchTableProbe races the WebRTC/signaling handshake against two timeouts) and shows a blocking dialog (join_dialog.js + new ui.js dialog functions) offering "Join this table" / "Create this table" / "Proceed offline" depending on what the probe finds.

tables.js's getYDoc now returns { ydoc, wasFresh } so callers can tell a genuinely-new local table apart from a returning one — the signal the Start Here marker turned out to still be necessary alongside, since seedTable stamps docId before index.html ever sees it.