### PR TITLE
File panel: exclude delight layer on export, import boundaries/positions

### DIFF
--- a/src/app.js
+++ b/src/app.js
@@ -1932,7 +1932,7 @@ const App = {
       _ydoc.transact(() => {
         result = Storage.populateFromSvgDoc(svgDoc.documentElement, _ydoc);
       });
-      const { toyCount, drawCount, invalidToyEls, importedToyEls } = result;
+      const { toyCount, drawCount, bounPosCount, invalidToyEls, importedToyEls } = result;
 
       if (toyCount) {
         const layerEl = _svgEl.querySelector('#toys-layer');
@@ -1952,6 +1952,7 @@ const App = {
       const parts = [];
       if (toyCount)  parts.push(`${toyCount} toy${toyCount === 1 ? '' : 's'}`);
       if (drawCount) parts.push(`${drawCount} shape${drawCount === 1 ? '' : 's'}`);
+      if (bounPosCount) parts.push(`${bounPosCount} boundary/position${bounPosCount === 1 ? '' : 's'}`);
       if (invalidToyEls.length) parts.push(`${invalidToyEls.length} invalid → errors layer`);
       if (!parts.length) UI.toast('Nothing importable found', 'warn');
       else UI.toast(`Imported: ${parts.join(', ')}`);

--- a/src/storage.js
+++ b/src/storage.js
@@ -32,11 +32,12 @@ export function domToY(node) {
 }
 
 /**
- * Populate a Yjs document (yMeta/yToys/yDrawing, all obtained directly off
- * ydoc) from a source <svg> root element — background pattern, #toys-layer,
- * #drawing-layer, and (as a fallback) any other top-level elements not
- * belonging to a known layer. Caller is responsible for wrapping this in a
- * ydoc.transact() if atomicity matters.
+ * Populate a Yjs document (yMeta/yToys/yDrawing/yBounPos, all obtained
+ * directly off ydoc) from a source <svg> root element — background pattern,
+ * #toys-layer, #drawing-layer, #boundaries-positions-layer, and (as a
+ * fallback) any other top-level elements not belonging to a known layer.
+ * Caller is responsible for wrapping this in a ydoc.transact() if atomicity
+ * matters.
  *
  * opts.stripToyDecorative — drop each toy <g>'s `transform` attribute before
  * insertion. home.html's sampler templates carry a decorative rotation
@@ -55,19 +56,22 @@ export function domToY(node) {
  * used against a live table — its toy handling is a known gap, not
  * silently declared fixed here.
  *
- * Returns { toyCount, drawCount, invalidToyEls }. invalidToyEls are DOM
- * elements found directly inside #toys-layer that Toys.parseForeignToy
- * doesn't recognise as a toy; the caller decides what to do with them.
+ * Returns { toyCount, drawCount, bounPosCount, invalidToyEls }.
+ * invalidToyEls are DOM elements found directly inside #toys-layer that
+ * Toys.parseForeignToy doesn't recognise as a toy; the caller decides what
+ * to do with them.
  */
 export function populateFromSvgDoc(svgRootEl, ydoc, opts = {}) {
   const yMeta    = ydoc.getMap('meta');
   const yDrawing = ydoc.getXmlFragment('drawing');
+  const yBounPos = ydoc.getXmlFragment('boundaries');
 
-  const bgPattern   = svgRootEl.querySelector('defs pattern');
-  const toysLayerEl = svgRootEl.querySelector('#toys-layer');
-  const drawLayerEl = svgRootEl.querySelector('#drawing-layer');
+  const bgPattern    = svgRootEl.querySelector('defs pattern');
+  const toysLayerEl  = svgRootEl.querySelector('#toys-layer');
+  const drawLayerEl  = svgRootEl.querySelector('#drawing-layer');
+  const bounPosLayerEl = svgRootEl.querySelector('#boundaries-positions-layer');
 
-  let toyCount = 0, drawCount = 0;
+  let toyCount = 0, drawCount = 0, bounPosCount = 0;
   const invalidToyEls = [];
   const importedToyEls = [];
 
@@ -142,6 +146,19 @@ export function populateFromSvgDoc(svgRootEl, ydoc, opts = {}) {
     }
   }
 
+  // Boundaries and Positions layer. boun_pos.js's Yjs shape (a <g
+  // data-bounpos-type> with path/text[/circle] children) is exactly what a
+  // generic domToY() produces from the exported DOM (see boun_pos.js's
+  // toSVGEl functions) — extra DOM-only attributes like data-id/data-module
+  // ride along harmlessly since render() rebuilds child elements fresh from
+  // the attributes it actually reads.
+  if (bounPosLayerEl) {
+    for (const child of bounPosLayerEl.children) {
+      const yEl = domToY(child);
+      if (yEl) { yBounPos.insert(yBounPos.length, [yEl]); bounPosCount++; }
+    }
+  }
+
   // Everything else → drawing layer
   for (const el of svgRootEl.children) {
     const id = el.getAttribute('id') ?? '';
@@ -149,15 +166,14 @@ export function populateFromSvgDoc(svgRootEl, ydoc, opts = {}) {
     if (el.localName === 'script') continue; // handled above
     if (id === 'toys-layer' || id === 'drawing-layer') continue;
     if (id === 'background-layer') continue;
-    // TODO: boundaries-positions import into its own Yjs fragment when implemented
-    if (id === 'boundaries-positions-layer') continue;
+    if (id === 'boundaries-positions-layer') continue; // handled above
     // overlay-layer is UI-only and is stripped on export
     if (id === 'overlay-layer') continue;
     const yEl = domToY(el);
     if (yEl) { yDrawing.insert(yDrawing.length, [yEl]); drawCount++; }
   }
 
-  return { toyCount, drawCount, invalidToyEls, importedToyEls };
+  return { toyCount, drawCount, bounPosCount, invalidToyEls, importedToyEls };
 }
 
 // ── Yjs → DOM (export) ────────────────────────────────────────────────────────
@@ -188,7 +204,7 @@ export function buildExportSvg(liveSvgEl, ydoc) {
 
   const clone = liveSvgEl.cloneNode(true);
   clone.removeAttribute('id');
-  ['#overlay-layer', '#draw-preview'].forEach(sel => {
+  ['#overlay-layer', '#draw-preview', '#delight-layer'].forEach(sel => {
     clone.querySelector(sel)?.remove();
   });
 

--- a/tests/unit/storage.test.js
+++ b/tests/unit/storage.test.js
@@ -7,6 +7,7 @@ import { projectFrom } from '../../src/op_checkpoint.js'
 import * as Toys from '../../src/toys.js'
 import { addToy, findToy, _clearSvgTextCache, _getScriptsFragment } from '../../src/toys.js'
 import { addDrawing } from '../../src/drawing.js'
+import * as BounPos from '../../src/boun_pos.js'
 
 // ── Fixtures & helpers ──────────────────────────────────────────────────────
 
@@ -183,6 +184,63 @@ describe('populateFromSvgDoc', () => {
     expect(drawCount).toBe(1) // only the <rect>, not toys/drawing/background/boundaries-positions layers again
   })
 
+  describe('boundaries-positions-layer', () => {
+    // Build the layer's inner markup the same way buildExportSvg does: a
+    // live render of BounPos-created elements via BounPos.render().
+    function exportedBounPosInner() {
+      const srcDoc = new Y.Doc()
+      const srcYBounPos = srcDoc.getXmlFragment('boundaries')
+      BounPos.addBoundary(srcDoc, srcYBounPos, { id: 'tt-b-v1-abc', name: 'Hand', x: 10, y: 20, w: 100, h: 50 })
+      BounPos.addPositionSet(srcDoc, srcYBounPos, {
+        x: 0, y: 0, w: 200, h: 200, toolName: 'pos-grid-sq', toolParams: { spacing: 80, snapRadius: 2 },
+      })
+      const layerEl = document.createElementNS('http://www.w3.org/2000/svg', 'g')
+      BounPos.render(srcYBounPos, layerEl)
+      return layerEl.innerHTML
+    }
+
+    test('imports boundaries and position sets into the boundaries Yjs fragment', () => {
+      const { ydoc } = freshLayers()
+      const yBounPos = ydoc.getXmlFragment('boundaries')
+      const { bounPosCount } = populateFromSvgDoc(
+        makeDocSvg({ extra: `` }), ydoc)
+      expect(bounPosCount).toBe(0)
+      expect(yBounPos.toArray().length).toBe(0)
+
+      const doc = parseSvg(`<svg xmlns="http://www.w3.org/2000/svg">
+        <g id="boundaries-positions-layer">${exportedBounPosInner()}</g>
+        <g id="toys-layer"></g>
+        <g id="drawing-layer"></g>
+      </svg>`)
+      const result = populateFromSvgDoc(doc, ydoc)
+      expect(result.bounPosCount).toBe(2)
+      expect(yBounPos.toArray().length).toBe(2)
+
+      const boundary = yBounPos.toArray().find(el => el.getAttribute('data-bounpos-type') === 'boundary')
+      expect(BounPos.getTtState(boundary)).toMatchObject({ id: 'tt-b-v1-abc', name: 'Hand', x: 10, y: 20, w: 100, h: 50 })
+
+      const posSet = yBounPos.toArray().find(el => el.getAttribute('data-bounpos-type') === 'pos-set')
+      expect(BounPos.getTtState(posSet)).toMatchObject({ bounPosType: 'pos-set', genType: 'square' })
+
+      // The imported fragment renders back into live SVG without error.
+      const rendered = document.createElementNS('http://www.w3.org/2000/svg', 'g')
+      BounPos.render(yBounPos, rendered)
+      expect(rendered.querySelectorAll('[data-bounpos-type]').length).toBe(2)
+    })
+
+    test('does not double-import via the fallback sweep', () => {
+      const { ydoc } = freshLayers()
+      const doc = parseSvg(`<svg xmlns="http://www.w3.org/2000/svg">
+        <g id="boundaries-positions-layer">${exportedBounPosInner()}</g>
+        <g id="toys-layer"></g>
+        <g id="drawing-layer"></g>
+      </svg>`)
+      const { bounPosCount, drawCount } = populateFromSvgDoc(doc, ydoc)
+      expect(bounPosCount).toBe(2)
+      expect(drawCount).toBe(0)
+    })
+  })
+
   test('hoists a script from an imported toy into the scripts fragment, stripped from the toy itself', () => {
     const { ydoc } = freshLayers()
     const toyWithScript = `<g class="toy" data-id="t1" data-toy-type="dice_d6">
@@ -307,6 +365,7 @@ describe('buildExportSvg', () => {
       <g id="toys-layer"></g>
       <g id="drawing-layer"></g>
       <g id="overlay-layer" pointer-events="none"></g>
+      <g id="delight-layer"><g class="actionColorGroup"></g></g>
     </svg>`)
   }
 
@@ -314,6 +373,12 @@ describe('buildExportSvg', () => {
     const ydoc = new Y.Doc()
     const clone = buildExportSvg(liveCanvasSvg(), ydoc)
     expect(clone.querySelector('#overlay-layer')).toBeNull()
+  })
+
+  test('removes the delight layer', () => {
+    const ydoc = new Y.Doc()
+    const clone = buildExportSvg(liveCanvasSvg(), ydoc)
+    expect(clone.querySelector('#delight-layer')).toBeNull()
   })
 
   test('strips pointer-events attributes throughout', () => {


### PR DESCRIPTION
buildExportSvg now strips #delight-layer alongside #overlay-layer and #draw-preview — it's ephemeral gesture UI, never canonical document state.

populateFromSvgDoc now reads #boundaries-positions-layer children into the Yjs 'boundaries' fragment (previously skipped with a TODO), matching boun_pos.js's Y.XmlElement shape. App.importSVG reports the imported count alongside toys/shapes.