### PR TITLE
Rename user id prefix from tt-p-v1 to tt-u-v1

### DIFF
--- a/src/tables.js
+++ b/src/tables.js
@@ -160,7 +160,7 @@ function resetJoinSequence(ydoc, orderedIds) {
 // ── Player options (per-player, per-table key-value store) ─────────────
 //
 // `playerOptions` is a Y.Map living in the document, keyed by *player* id
-// (user.js's persistent localId — tt-p-v1-DD-XXX — not the ephemeral Yjs
+// (user.js's persistent localId — tt-u-v1-DD-XXX — not the ephemeral Yjs
 // clientID a browser tab mints per session). Each value is itself a
 // Y.Map: that player's own key-value store, scoped to this one table.
 // Because it lives inside the table's own Y.Doc, the same player has an

--- a/src/user.js
+++ b/src/user.js
@@ -7,7 +7,7 @@
  *   grad    — full entityGradient() output object, stored frozen so the
  *             gradient is immune to future changes in entityGradient's
  *             algorithm
- *   localId — persistent peer id, format tt-p-v1-DD-XXX
+ *   localId — persistent peer id, format tt-u-v1-DD-XXX
  *   checkpointFrequency — minutes between idle-triggered checkpoints, 0-10.
  *             any other player's client does.
  *
@@ -52,7 +52,7 @@ export function randomName() {
 }
 
 /**
- * Generates a fresh persistent peer id, format tt-p-v1-DD-XXX where DD is
+ * Generates a fresh persistent peer id, format tt-u-v1-DD-XXX where DD is
  * the current day-of-month and XXX is 3 random lowercase letters.
  *
  * @returns {string}
@@ -61,7 +61,7 @@ export function makeLocalId() {
   const dd    = String(new Date().getDate()).padStart(2, '0');
   const chars = 'abcdefghijklmnopqrstuvwxyz';
   const rand  = Array.from({ length: 3 }, () => chars[Math.floor(Math.random() * chars.length)]).join('');
-  return `tt-p-v1-${dd}-${rand}`;
+  return `tt-u-v1-${dd}-${rand}`;
 }
 
 /**
@@ -170,7 +170,7 @@ export function setGrad(grad) {
  * Returns this player's durable identity as a `user` object — the same
  * {id, name, color, gradient} shape broadcast to peers over awareness
  * (see index.html) and read back via App.user / a peer's awareness
- * state.user. `id` is the persistent localId (tt-p-v1-...), stable
+ * state.user. `id` is the persistent localId (tt-u-v1-...), stable
  * across reconnects and reloads, unlike the ephemeral Yjs clientID.
  *
  * @returns {{id: string, name: string, color: string, gradient: object}}

--- a/tests/unit/debug-panel.test.js
+++ b/tests/unit/debug-panel.test.js
@@ -28,21 +28,21 @@ const parse = (html) => {
 
 const makeState = (over = {}) => ({
   table:    { tableId: 'demo-table', isCreator: true, schema: 4 },
-  identity: { myId: 'tt-p-v1-AA-abc', clientId: 12345 },
+  identity: { myId: 'tt-u-v1-AA-abc', clientId: 12345 },
   head:     { head: 'tt-op-aaa', mergeTips: [], projected: 'tt-op-aaa', agrees: true },
   ops:      { total: 2, shown: 2, truncated: false, tips: ['tt-op-bbb'], checkpoints: 1, mine: 1,
               ordered: [
-                { i: 0, id: 'tt-op-aaa', gesture: 'checkpoint', authorId: 'tt-p-v1-AA-abc',
+                { i: 0, id: 'tt-op-aaa', gesture: 'checkpoint', authorId: 'tt-u-v1-AA-abc',
                   parents: [], ts: 1700000000000, mine: true, checkpoint: true,
                   entries: 1, mutations: [{ t: 'child', target: { id: 'tt-layer-toys' } }] },
-                { i: 1, id: 'tt-op-bbb', gesture: 'move', authorId: 'tt-p-v1-BB-xyz',
+                { i: 1, id: 'tt-op-bbb', gesture: 'move', authorId: 'tt-u-v1-BB-xyz',
                   parents: ['tt-op-aaa'], ts: 1700000001000, mine: false, checkpoint: false,
                   entries: 2, mutations: [{ t: 'attr', name: 'transform' }] },
               ] },
   net:      { connected: true, synced: true, webrtcPeers: 1, bcPeers: 0,
               signaling: ['ws://localhost:4444'], offline: false,
-              peers: [{ clientId: 1, peerId: 'tt-p-v1-AA-abc', self: true }] },
-  joinSequence: ['tt-p-v1-AA-abc', 'tt-p-v1-BB-xyz'],
+              peers: [{ clientId: 1, peerId: 'tt-u-v1-AA-abc', self: true }] },
+  joinSequence: ['tt-u-v1-AA-abc', 'tt-u-v1-BB-xyz'],
   myAuthorityIndex: 0,
   ...over,
 })
@@ -116,7 +116,7 @@ describe('stateHTML', () => {
     const d = parse(stateHTML(makeState()))
     const mine = d.querySelectorAll('.dbg-join-row.me')
     expect(mine).toHaveLength(1)
-    expect(mine[0].querySelector('.dbg-id').getAttribute('title')).toBe('tt-p-v1-AA-abc')
+    expect(mine[0].querySelector('.dbg-id').getAttribute('title')).toBe('tt-u-v1-AA-abc')
   })
 
   test('renders a message rather than throwing when there is no state', () => {
@@ -125,7 +125,7 @@ describe('stateHTML', () => {
 })
 
 describe('joinSequenceHTML', () => {
-  const seq = ['tt-p-v1-AA-abc', 'tt-p-v1-BB-xyz', 'tt-p-v1-CC-qrs']
+  const seq = ['tt-u-v1-AA-abc', 'tt-u-v1-BB-xyz', 'tt-u-v1-CC-qrs']
 
   test('renders one row per entry, in order, with its index', () => {
     const d = parse(joinSequenceHTML(seq, null, new Set()))
@@ -135,7 +135,7 @@ describe('joinSequenceHTML', () => {
   })
 
   test('marks my own row', () => {
-    const d = parse(joinSequenceHTML(seq, 'tt-p-v1-BB-xyz', new Set()))
+    const d = parse(joinSequenceHTML(seq, 'tt-u-v1-BB-xyz', new Set()))
     const rows = d.querySelectorAll('.dbg-join-row')
     expect(rows[0].classList.contains('me')).toBe(false)
     expect(rows[1].classList.contains('me')).toBe(true)
@@ -149,7 +149,7 @@ describe('joinSequenceHTML', () => {
   })
 
   test('online/offline is read off current presence, independent of position', () => {
-    const d = parse(joinSequenceHTML(seq, null, new Set(['tt-p-v1-BB-xyz'])))
+    const d = parse(joinSequenceHTML(seq, null, new Set(['tt-u-v1-BB-xyz'])))
     const rows = d.querySelectorAll('.dbg-join-row')
     expect(rows[0].querySelector('.dbg-join-dot').classList.contains('offline')).toBe(true)
     expect(rows[1].querySelector('.dbg-join-dot').classList.contains('online')).toBe(true)
@@ -162,7 +162,7 @@ describe('joinSequenceHTML', () => {
 
   test('carries the raw array for exact inspection', () => {
     const d = parse(joinSequenceHTML(seq, null, new Set()))
-    expect(d.querySelector('.dbg-join-raw .dbg-json').textContent).toContain('tt-p-v1-CC-qrs')
+    expect(d.querySelector('.dbg-join-raw .dbg-json').textContent).toContain('tt-u-v1-CC-qrs')
   })
 })
 

--- a/tests/unit/tables-authority.test.js
+++ b/tests/unit/tables-authority.test.js
@@ -21,8 +21,8 @@ function rawJoinSequence(ydoc) {
 describe('ensureJoined', () => {
   test('the creator appends a fresh id to an empty joinSequence', () => {
     const ydoc = new Y.Doc()
-    ensureJoined(ydoc, 'tt-p-v1-01-aaa', { isCreator: true })
-    expect(rawJoinSequence(ydoc).toArray()).toEqual(['tt-p-v1-01-aaa'])
+    ensureJoined(ydoc, 'tt-u-v1-01-aaa', { isCreator: true })
+    expect(rawJoinSequence(ydoc).toArray()).toEqual(['tt-u-v1-01-aaa'])
   })
 
   test('a joiner (isCreator: false) defers on an empty joinSequence instead of inserting', () => {
@@ -44,10 +44,10 @@ describe('ensureJoined', () => {
 
   test('is idempotent — calling again for the same id does not re-append', () => {
     const ydoc = new Y.Doc()
-    ensureJoined(ydoc, 'tt-p-v1-01-aaa', { isCreator: true })
-    ensureJoined(ydoc, 'tt-p-v1-01-aaa', { isCreator: true })
-    ensureJoined(ydoc, 'tt-p-v1-01-aaa', { isCreator: true })
-    expect(rawJoinSequence(ydoc).toArray()).toEqual(['tt-p-v1-01-aaa'])
+    ensureJoined(ydoc, 'tt-u-v1-01-aaa', { isCreator: true })
+    ensureJoined(ydoc, 'tt-u-v1-01-aaa', { isCreator: true })
+    ensureJoined(ydoc, 'tt-u-v1-01-aaa', { isCreator: true })
+    expect(rawJoinSequence(ydoc).toArray()).toEqual(['tt-u-v1-01-aaa'])
   })
 
   test('preserves join order across multiple distinct peers', () => {

--- a/tests/unit/tables-player-options.test.js
+++ b/tests/unit/tables-player-options.test.js
@@ -10,29 +10,29 @@ const { recordRecentToy, getRecentToys, ensurePlayerOptions } = tablesAPI
 describe('recentToys', () => {
   test('starts empty for a player who has never gestured on this table', () => {
     const ydoc = new Y.Doc()
-    expect(getRecentToys(ydoc, 'tt-p-v1-01-aaa')).toEqual([])
+    expect(getRecentToys(ydoc, 'tt-u-v1-01-aaa')).toEqual([])
   })
 
   test('records a gesture, most-recent first', () => {
     const ydoc = new Y.Doc()
-    recordRecentToy(ydoc, 'tt-p-v1-01-aaa', 'toy-1')
-    recordRecentToy(ydoc, 'tt-p-v1-01-aaa', 'toy-2')
-    recordRecentToy(ydoc, 'tt-p-v1-01-aaa', 'toy-3')
-    expect(getRecentToys(ydoc, 'tt-p-v1-01-aaa')).toEqual(['toy-3', 'toy-2', 'toy-1'])
+    recordRecentToy(ydoc, 'tt-u-v1-01-aaa', 'toy-1')
+    recordRecentToy(ydoc, 'tt-u-v1-01-aaa', 'toy-2')
+    recordRecentToy(ydoc, 'tt-u-v1-01-aaa', 'toy-3')
+    expect(getRecentToys(ydoc, 'tt-u-v1-01-aaa')).toEqual(['toy-3', 'toy-2', 'toy-1'])
   })
 
   test('re-gesturing an already-present toy moves it to the front instead of duplicating', () => {
     const ydoc = new Y.Doc()
-    recordRecentToy(ydoc, 'tt-p-v1-01-aaa', 'toy-1')
-    recordRecentToy(ydoc, 'tt-p-v1-01-aaa', 'toy-2')
-    recordRecentToy(ydoc, 'tt-p-v1-01-aaa', 'toy-1')
-    expect(getRecentToys(ydoc, 'tt-p-v1-01-aaa')).toEqual(['toy-1', 'toy-2'])
+    recordRecentToy(ydoc, 'tt-u-v1-01-aaa', 'toy-1')
+    recordRecentToy(ydoc, 'tt-u-v1-01-aaa', 'toy-2')
+    recordRecentToy(ydoc, 'tt-u-v1-01-aaa', 'toy-1')
+    expect(getRecentToys(ydoc, 'tt-u-v1-01-aaa')).toEqual(['toy-1', 'toy-2'])
   })
 
   test('recentToys can be different on two different tables for the SAME player', () => {
     const tableA = new Y.Doc()
     const tableB = new Y.Doc()
-    const playerId = 'tt-p-v1-01-aaa'
+    const playerId = 'tt-u-v1-01-aaa'
 
     recordRecentToy(tableA, playerId, 'toy-map')
     recordRecentToy(tableA, playerId, 'toy-dice')
@@ -53,7 +53,7 @@ describe('recentToys', () => {
 
   test('caps the list at MAX_RECENT_TOYS, dropping the oldest', () => {
     const ydoc = new Y.Doc()
-    const playerId = 'tt-p-v1-01-aaa'
+    const playerId = 'tt-u-v1-01-aaa'
     for (let i = 0; i < 15; i++) recordRecentToy(ydoc, playerId, `toy-${i}`)
     const recent = getRecentToys(ydoc, playerId)
     expect(recent.length).toBe(10)
@@ -65,15 +65,15 @@ describe('recentToys', () => {
 describe('ensurePlayerOptions', () => {
   test('is idempotent — returns the same Y.Map on repeated calls', () => {
     const ydoc = new Y.Doc()
-    const first  = ensurePlayerOptions(ydoc, 'tt-p-v1-01-aaa')
-    const second = ensurePlayerOptions(ydoc, 'tt-p-v1-01-aaa')
+    const first  = ensurePlayerOptions(ydoc, 'tt-u-v1-01-aaa')
+    const second = ensurePlayerOptions(ydoc, 'tt-u-v1-01-aaa')
     expect(first).toBe(second)
   })
 
   test('playerOptions lives under its own top-level Y.Map, keyed by player id', () => {
     const ydoc = new Y.Doc()
-    ensurePlayerOptions(ydoc, 'tt-p-v1-01-aaa')
+    ensurePlayerOptions(ydoc, 'tt-u-v1-01-aaa')
     const root = ydoc.getMap('playerOptions')
-    expect(root.get('tt-p-v1-01-aaa')).toBeInstanceOf(Y.Map)
+    expect(root.get('tt-u-v1-01-aaa')).toBeInstanceOf(Y.Map)
   })
 })

--- a/tests/unit/user.test.js
+++ b/tests/unit/user.test.js
@@ -22,14 +22,14 @@ describe('getIdentity', () => {
     expect(identity.name.length).toBeGreaterThan(0)
     expect(identity.grad).toBeTruthy()
     expect(typeof identity.grad.c1).toBe('string')
-    expect(identity.localId).toMatch(/^tt-p-v1-\d{2}-[a-z]{3}$/)
+    expect(identity.localId).toMatch(/^tt-u-v1-\d{2}-[a-z]{3}$/)
 
     const stored = JSON.parse(localStorage.getItem(STORAGE_KEY))
     expect(stored).toEqual(identity)
   })
 
   test('reads back a previously persisted identity', () => {
-    const record = { name: 'Existing Player', grad: { c1: 'hsl(1,2%,3%)', c2: 'hsl(4,5%,6%)' }, localId: 'tt-p-v1-05-xyz', checkpointFrequency: 3 }
+    const record = { name: 'Existing Player', grad: { c1: 'hsl(1,2%,3%)', c2: 'hsl(4,5%,6%)' }, localId: 'tt-u-v1-05-xyz', checkpointFrequency: 3 }
     localStorage.setItem(STORAGE_KEY, JSON.stringify(record))
 
     expect(getIdentity()).toEqual(record)
@@ -42,17 +42,17 @@ describe('getIdentity', () => {
     const identity = getIdentity()
     expect(identity.name).toBe('Partial Player')
     expect(identity.grad).toEqual(record.grad)
-    expect(identity.localId).toMatch(/^tt-p-v1-\d{2}-[a-z]{3}$/)
+    expect(identity.localId).toMatch(/^tt-u-v1-\d{2}-[a-z]{3}$/)
   })
 
   test('heals a record with a malformed grad (missing c1)', () => {
-    const record = { name: 'Broken Grad', grad: { oops: true }, localId: 'tt-p-v1-05-xyz' }
+    const record = { name: 'Broken Grad', grad: { oops: true }, localId: 'tt-u-v1-05-xyz' }
     localStorage.setItem(STORAGE_KEY, JSON.stringify(record))
 
     const identity = getIdentity()
     expect(identity.grad.c1).toBeTruthy()
     expect(identity.name).toBe('Broken Grad')
-    expect(identity.localId).toBe('tt-p-v1-05-xyz')
+    expect(identity.localId).toBe('tt-u-v1-05-xyz')
   })
 
   test('falls back to a fresh identity when stored JSON is corrupt', () => {
@@ -61,7 +61,7 @@ describe('getIdentity', () => {
     const identity = getIdentity()
     expect(identity.name).toBeTruthy()
     expect(identity.grad.c1).toBeTruthy()
-    expect(identity.localId).toMatch(/^tt-p-v1-\d{2}-[a-z]{3}$/)
+    expect(identity.localId).toMatch(/^tt-u-v1-\d{2}-[a-z]{3}$/)
   })
 
   test('falls back to a fresh identity when the key is absent', () => {
@@ -71,13 +71,13 @@ describe('getIdentity', () => {
   })
 
   test('heals a record missing checkpointFrequency without touching other fields', () => {
-    const record = { name: 'No Freq Player', grad: { c1: 'hsl(1,2%,3%)', c2: 'hsl(4,5%,6%)' }, localId: 'tt-p-v1-05-xyz' }
+    const record = { name: 'No Freq Player', grad: { c1: 'hsl(1,2%,3%)', c2: 'hsl(4,5%,6%)' }, localId: 'tt-u-v1-05-xyz' }
     localStorage.setItem(STORAGE_KEY, JSON.stringify(record))
 
     const identity = getIdentity()
     expect(identity.checkpointFrequency).toBe(DEFAULT_CHECKPOINT_FREQUENCY)
     expect(identity.name).toBe('No Freq Player')
-    expect(identity.localId).toBe('tt-p-v1-05-xyz')
+    expect(identity.localId).toBe('tt-u-v1-05-xyz')
   })
 })
 
@@ -120,8 +120,8 @@ describe('randomName', () => {
 })
 
 describe('makeLocalId', () => {
-  test('returns a tt-p-v1-DD-XXX formatted id', () => {
-    expect(makeLocalId()).toMatch(/^tt-p-v1-\d{2}-[a-z]{3}$/)
+  test('returns a tt-u-v1-DD-XXX formatted id', () => {
+    expect(makeLocalId()).toMatch(/^tt-u-v1-\d{2}-[a-z]{3}$/)
   })
 })
 
@@ -155,18 +155,18 @@ describe('setCheckpointFrequency', () => {
 
 describe('getMyUser', () => {
   test('derives {id, name, color, gradient} from the persisted identity', () => {
-    const record = { name: 'Wily Frodo', grad: { c1: 'hsl(1,2%,3%)', c2: 'hsl(4,5%,6%)' }, localId: 'tt-p-v1-05-xyz' }
+    const record = { name: 'Wily Frodo', grad: { c1: 'hsl(1,2%,3%)', c2: 'hsl(4,5%,6%)' }, localId: 'tt-u-v1-05-xyz' }
     localStorage.setItem(STORAGE_KEY, JSON.stringify(record))
 
     expect(getMyUser()).toEqual({
-      id: 'tt-p-v1-05-xyz', name: 'Wily Frodo',
+      id: 'tt-u-v1-05-xyz', name: 'Wily Frodo',
       color: 'hsl(1,2%,3%)', gradient: record.grad,
     })
   })
 
   test('generates and persists a fresh identity on first call, same as getIdentity', () => {
     const user = getMyUser()
-    expect(user.id).toMatch(/^tt-p-v1-\d{2}-[a-z]{3}$/)
+    expect(user.id).toMatch(/^tt-u-v1-\d{2}-[a-z]{3}$/)
     expect(user.name.length).toBeGreaterThan(0)
     expect(user.color).toBe(user.gradient.c1)
   })


### PR DESCRIPTION
Straight string refactor of the persistent player-identity id format, across the generator, comments, and tests.


Claude-Session: https://claude.ai/code/session_01RBFmSkmCgnajkrbgRmirYB