### PR TITLE
Remove the #statusBar debug element

### DIFF
--- a/src/app.js
+++ b/src/app.js
@@ -436,9 +436,7 @@ export function boot({ ydoc, awareness, provider, user, tableId, isCreator = fal
   });
 
   // Provider status
-  const dot = document.getElementById('statusDot');
   _provider.on('synced', () => {
-    if (dot) dot.className = 'status-dot connected';
     _netStatus.synced = true;
     Trace.net('synced', 'provider reports synced with peers', { ops: getOps(_ydoc).size });
     UI.toast('Synced with peers');
@@ -459,7 +457,6 @@ export function boot({ ydoc, awareness, provider, user, tableId, isCreator = fal
   // NOTE: _provider.on('status' is a red herring. It's just true after
   // construction. We really want the real connect/disconnect state
   const setSignalingConnected = (connected) => {
-    if (dot) dot.className = connected ? 'status-dot connected' : 'status-dot connecting';
     _netStatus.connected = connected;
     Trace.net('status', connected ? 'signaling connected' : 'signaling disconnected',
       { connected }, connected ? 'info' : 'warn');
@@ -550,14 +547,12 @@ function renderDoc() {
   renderToysLayer();
   renderDrawingLayer();
   applyLayerVisibility();
-  updatePeerCount();
   Overlay.render();          // doc geometry may have changed under selections
 }
 
 function renderPresence() {
   syncUserVisuals();
   Overlay.syncFromAwareness(_awareness.getStates(), _awareness.clientID);
-  updatePeerCount();
 }
 
 // Keeps every live peer's (and my own) <linearGradient id="grad-{id}">
@@ -715,13 +710,6 @@ function onOpsChanged(evt, transaction) {
   Overlay.render();
 }
 
-
-function updatePeerCount() {
-  let peers = 0;
-  _awareness.getStates().forEach((_, cid) => { if (cid !== _awareness.clientID) peers++; });
-  const el = document.getElementById('peerCount');
-  if (el) el.textContent = peers;
-}
 
 // ── CRDT observers ────────────────────────────────────────────────────────────
 function onDocChanged() {

--- a/src/index.html
+++ b/src/index.html
@@ -174,17 +174,6 @@
   <div class="dialog-actions" id="joinDialogActions"></div>
 </div>
 
-<!-- ── Status bar (retained from old index.html for debugging) ────────────── -->
-<div id="statusBar" style="position:fixed;top:0;left:50%;transform:translateX(-50%);
-     font-size:11px;color:var(--text-3);pointer-events:none;z-index:100;
-     display:flex;gap:10px;padding:4px 8px">
-  <span id="tableLabel" style="font-family:monospace"></span>
-  <span id="myIdLabel" style="font-family:monospace"></span>
-  <span class="status-dot" id="statusDot" style="width:8px;height:8px;border-radius:50%;
-        background:var(--warn);align-self:center;flex-shrink:0"></span>
-  <span>peers: <span id="peerCount">0</span></span>
-</div>
-
 <!-- ── Module imports ─────────────────────────────────────────────────────── -->
 <script type="importmap">
 {
@@ -226,7 +215,6 @@ window.App = App;
 // ── Identity ────────────────────────────────────────────────────────────────
 // Persistent identity lives in localStorage
 const user = getMyUser();
-document.getElementById('myIdLabel').textContent = `me: ${user.name}`;
 Trace.boot('identity', `local identity resolved: ${user.name}`, { user });
 
 // ── Table  ──────────────────────────────────────────────────────────────────
@@ -237,7 +225,6 @@ if (noHash) {
   tableId = tables.generateTableId(user.name);
   location.hash = tableId;
 }
-document.getElementById('tableLabel').textContent = tableId;
 Trace.boot('table-id', noHash ? `minted a new table: ${tableId}` : `joining table: ${tableId}`,
   { tableId, noHash, hash: location.hash });
 

--- a/tests/e2e/boundary-drag.spec.js
+++ b/tests/e2e/boundary-drag.spec.js
@@ -16,7 +16,7 @@
  */
 
 import { test, expect, chromium } from '@playwright/test';
-import { openAsCreator } from './helpers.js';
+import { openAsCreator, waitForPeerCount } from './helpers.js';
 
 const APP_URL      = process.env.APP_URL      || 'http://localhost:3000';
 const SIGNALING_URL = process.env.SIGNALING_URL || 'ws://localhost:4444';
@@ -30,7 +30,7 @@ test.describe('boundary-constrained toy dragging', () => {
     await openAsCreator(page, { appUrl: APP_URL, signalingUrl: SIGNALING_URL });
 
     // Wait for app to boot (same pattern as sync.spec.js)
-    await expect(page.locator('#peerCount')).toHaveText('0', { timeout: 8000 });
+    await waitForPeerCount(page, 0);
 
     const canvas    = page.locator('#canvas');
     const canvasBox = await canvas.boundingBox();

--- a/tests/e2e/container-drop.spec.js
+++ b/tests/e2e/container-drop.spec.js
@@ -13,7 +13,7 @@
  */
 
 import { test, expect, chromium } from '@playwright/test';
-import { openCreatorAndJoiner, openAsCreator } from './helpers.js';
+import { openCreatorAndJoiner, openAsCreator, waitForPeerCount } from './helpers.js';
 
 const APP_URL = process.env.APP_URL || 'http://localhost:3000';
 const SIGNALING_URL = process.env.SIGNALING_URL || 'ws://localhost:4444';
@@ -27,8 +27,8 @@ test.describe('two-peer container drop sync', () => {
     const page2   = await ctx2.newPage();
 
     await openCreatorAndJoiner(page1, page2, { appUrl: APP_URL, signalingUrl: SIGNALING_URL });
-    await expect(page1.locator('#peerCount')).toHaveText('1', { timeout: 8000 });
-    await expect(page2.locator('#peerCount')).toHaveText('1', { timeout: 8000 });
+    await waitForPeerCount(page1, 1);
+    await waitForPeerCount(page2, 1);
 
     const canvas = page1.locator('#canvas');
     const box    = await canvas.boundingBox();

--- a/tests/e2e/hashchange.spec.js
+++ b/tests/e2e/hashchange.spec.js
@@ -12,7 +12,7 @@
  */
 
 import { test, expect, chromium } from '@playwright/test';
-import { openAsCreator } from './helpers.js';
+import { openAsCreator, waitForTableId } from './helpers.js';
 
 const APP_URL       = process.env.APP_URL       || 'http://localhost:3000';
 const SIGNALING_URL = process.env.SIGNALING_URL || 'ws://localhost:4444';
@@ -30,7 +30,7 @@ test.describe('hashchange table navigation', () => {
     });
 
     const room = await openAsCreator(page, { appUrl: APP_URL, signalingUrl: SIGNALING_URL });
-    await expect(page.locator('#tableLabel')).toHaveText(room);
+    await waitForTableId(page, room);
     await page.waitForTimeout(300); // give a spurious hashchange reload a chance to happen
 
     expect(await page.evaluate(() => sessionStorage.getItem('__loads'))).toBe('1');
@@ -47,17 +47,19 @@ test.describe('hashchange table navigation', () => {
     });
 
     const tableA = await openAsCreator(page, { appUrl: APP_URL, signalingUrl: SIGNALING_URL });
-    await expect(page.locator('#tableLabel')).toHaveText(tableA);
+    await waitForTableId(page, tableA);
     expect(await page.evaluate(() => sessionStorage.getItem('__loads'))).toBe('1');
 
     const tableB = 'tt-T-v1-e2ehashtest';
     await page.evaluate((id) => { location.hash = id; }, tableB);
 
-    // The listener reloads the page onto tableB; the status bar reflects
-    // whatever table is currently booted, so it's the signal that the
-    // reload landed and the new table's boot ran.
-    await expect(page.locator('#tableLabel')).toHaveText(tableB, { timeout: 8000 });
-    await expect.poll(() => page.evaluate(() => location.hash.slice(1))).toBe(tableB);
+    // The listener reloads the page onto tableB. tableB is a table nobody
+    // has seen before, so the reloaded page's isCreator resolution blocks
+    // on the join-intent dialog — App.getTableId() wouldn't settle until
+    // that's dismissed. location.hash lands on tableB immediately, and
+    // waitForFunction (unlike a bare evaluate poll) survives the reload's
+    // execution-context swap, so it's the signal that the reload landed.
+    await page.waitForFunction((id) => location.hash.slice(1) === id, tableB, { timeout: 8000 });
 
     // Exactly one reload happened — not zero (the hash change was ignored)
     // and not more than one (no reload loop from the listener re-triggering

--- a/tests/e2e/helpers.js
+++ b/tests/e2e/helpers.js
@@ -1,3 +1,5 @@
+import { expect } from '@playwright/test';
+
 /**
  * tests/e2e/helpers.js
  *
@@ -87,4 +89,38 @@ export async function openCreatorAndJoiner(page1, page2, opts) {
   const room = await openAsCreator(page1, opts);
   await joinRoom(page2, room, opts);
   return room;
+}
+
+/**
+ * page.evaluate rejects with "Execution context was destroyed" when a
+ * navigation (e.g. a hashchange-triggered reload) lands mid-poll. Treat
+ * that the same as any other not-yet-matching value instead of aborting
+ * expect.poll, which — unlike locator assertions — doesn't retry on a
+ * thrown evaluate.
+ */
+async function evaluateOrUndefined(page, fn) {
+  try {
+    return await page.evaluate(fn);
+  } catch {
+    return undefined;
+  }
+}
+
+/**
+ * Polls App.getTableId() (see app.js; window.App is exposed by index.html)
+ * until it equals room. Stands in for the old #tableLabel status-bar text
+ * as the "boot landed on this table" signal.
+ */
+export async function waitForTableId(page, room, opts = {}) {
+  await expect.poll(() => evaluateOrUndefined(page, () => window.App.getTableId()), { timeout: 8000, ...opts })
+    .toBe(room);
+}
+
+/**
+ * Polls App.getPeers().length (see app.js) until it equals n. Stands in
+ * for the old #peerCount status-bar text as the peer-connected barrier.
+ */
+export async function waitForPeerCount(page, n, opts = {}) {
+  await expect.poll(() => evaluateOrUndefined(page, () => window.App.getPeers().length), { timeout: 8000, ...opts })
+    .toBe(n);
 }

--- a/tests/e2e/join-dialog.spec.js
+++ b/tests/e2e/join-dialog.spec.js
@@ -13,7 +13,7 @@
  */
 
 import { test, expect, chromium } from '@playwright/test';
-import { openAsCreator, seedJoinTimeouts, joinDialogButton } from './helpers.js';
+import { openAsCreator, seedJoinTimeouts, joinDialogButton, waitForTableId, waitForPeerCount } from './helpers.js';
 
 const APP_URL        = process.env.APP_URL       || 'http://localhost:3000';
 const SIGNALING_URL  = process.env.SIGNALING_URL || 'ws://localhost:4444';
@@ -61,7 +61,7 @@ test.describe('join-intent dialog', () => {
     // "/#tableId", others "/index.html#tableId" — so match on the hash
     // alone rather than assuming what precedes it.
     await page.waitForURL(/#tt-T-v1-/, { timeout: 10000 });
-    await expect(page.locator('#tableLabel')).not.toHaveText('', { timeout: 8000 });
+    await expect.poll(() => page.evaluate(() => window.App.getTableId()), { timeout: 8000 }).toBeTruthy();
     await page.waitForTimeout(300); // give a spurious dialog a chance to open
     await expect(page.locator('#joinDialogScrim')).not.toHaveClass(/open/);
 
@@ -73,7 +73,7 @@ test.describe('join-intent dialog', () => {
   test('returning visit (reload as creator): dialog never appears, and "created here" is still accurate', async ({ page }) => {
     const room = await openAsCreator(page, { appUrl: APP_URL, signalingUrl: SIGNALING_URL });
     await page.reload();
-    await expect(page.locator('#tableLabel')).toHaveText(room);
+    await waitForTableId(page, room);
     await page.waitForTimeout(300);
     await expect(page.locator('#joinDialogScrim')).not.toHaveClass(/open/);
 
@@ -105,8 +105,8 @@ test.describe('join-intent dialog', () => {
 
     await joinDialogButton(page2).click();
 
-    await expect(page1.locator('#peerCount')).toHaveText('1', { timeout: 8000 });
-    await expect(page2.locator('#peerCount')).toHaveText('1', { timeout: 8000 });
+    await waitForPeerCount(page1, 1);
+    await waitForPeerCount(page2, 1);
 
     await browser.close();
   });

--- a/tests/e2e/multiselect.spec.js
+++ b/tests/e2e/multiselect.spec.js
@@ -15,7 +15,7 @@
  */
 
 import { test, expect, chromium } from '@playwright/test';
-import { openAsCreator } from './helpers.js';
+import { openAsCreator, waitForPeerCount } from './helpers.js';
 
 const APP_URL       = process.env.APP_URL       || 'http://localhost:3000';
 const SIGNALING_URL = process.env.SIGNALING_URL || 'ws://localhost:4444';
@@ -27,7 +27,7 @@ test.describe('multi-select', () => {
     const page    = await ctx.newPage();
 
     await openAsCreator(page, { appUrl: APP_URL, signalingUrl: SIGNALING_URL });
-    await expect(page.locator('#peerCount')).toHaveText('0', { timeout: 8000 });
+    await waitForPeerCount(page, 0);
 
     const canvas    = page.locator('#canvas');
     const canvasBox = await canvas.boundingBox();

--- a/tests/e2e/soft-lock.spec.js
+++ b/tests/e2e/soft-lock.spec.js
@@ -30,7 +30,7 @@
  */
 
 import { test, expect, chromium } from '@playwright/test';
-import { openCreatorAndJoiner } from './helpers.js';
+import { openCreatorAndJoiner, waitForPeerCount } from './helpers.js';
 
 const APP_URL = process.env.APP_URL || 'http://localhost:3000';
 const SIGNALING_URL = process.env.SIGNALING_URL || 'ws://localhost:4444';
@@ -47,8 +47,8 @@ async function twoPeers(browser) {
 
   await openCreatorAndJoiner(page1, page2, { appUrl: APP_URL, signalingUrl: SIGNALING_URL });
 
-  await expect(page1.locator('#peerCount')).toHaveText('1', { timeout: 8000 });
-  await expect(page2.locator('#peerCount')).toHaveText('1', { timeout: 8000 });
+  await waitForPeerCount(page1, 1);
+  await waitForPeerCount(page2, 1);
 
   return { page1, page2 };
 }

--- a/tests/e2e/sync.spec.js
+++ b/tests/e2e/sync.spec.js
@@ -9,7 +9,7 @@
  */
 
 import { test, expect, chromium } from '@playwright/test';
-import { openAsCreator, joinRoom, openCreatorAndJoiner } from './helpers.js';
+import { openAsCreator, joinRoom, openCreatorAndJoiner, waitForPeerCount } from './helpers.js';
 
 const APP_URL = process.env.APP_URL || 'http://localhost:3000';
 const SIGNALING_URL = process.env.SIGNALING_URL || 'ws://localhost:4444';
@@ -24,14 +24,14 @@ test.describe('two-peer sync', () => {
     const page2   = await ctx2.newPage();
 
     await openAsCreator(page1, { appUrl: APP_URL, signalingUrl: SIGNALING_URL });
-    await expect(page1.locator('#peerCount')).toHaveText('0', { timeout: 8000 });
+    await waitForPeerCount(page1, 0);
     const room = await page1.evaluate(() => location.hash.slice(1));
 
     await joinRoom(page2, room, { appUrl: APP_URL, signalingUrl: SIGNALING_URL });
 
     // Wait for both peers to see each other
-    await expect(page1.locator('#peerCount')).toHaveText('1', { timeout: 8000 });
-    await expect(page2.locator('#peerCount')).toHaveText('1', { timeout: 8000 });
+    await waitForPeerCount(page1, 1);
+    await waitForPeerCount(page2, 1);
 
     // Sanity check - initially no toys on page2
     await expect(page2.locator('[data-toy-type]')).toHaveCount(0, { timeout: 5000 });
@@ -61,8 +61,8 @@ test.describe('two-peer sync', () => {
 
     await openCreatorAndJoiner(page1, page2, { appUrl: APP_URL, signalingUrl: SIGNALING_URL });
 
-    await expect(page1.locator('#peerCount')).toHaveText('1', { timeout: 8000 });
-    await expect(page2.locator('#peerCount')).toHaveText('1', { timeout: 8000 });
+    await waitForPeerCount(page1, 1);
+    await waitForPeerCount(page2, 1);
 
     // Sanity check - initially no toys on page2
     await expect(page2.locator('[data-toy-type]')).toHaveCount(0, { timeout: 5000 });
@@ -112,7 +112,7 @@ test.describe('two-peer sync', () => {
 
     await openCreatorAndJoiner(page1, page2, { appUrl: APP_URL, signalingUrl: SIGNALING_URL });
 
-    await expect(page1.locator('#peerCount')).toHaveText('1', { timeout: 8000 });
+    await waitForPeerCount(page1, 1);
 
     // Sanity check - initially no toys on page2
     await expect(page2.locator('[data-toy-type]')).toHaveCount(0, { timeout: 5000 });
@@ -168,8 +168,8 @@ test.describe('two-peer sync', () => {
 
     await openCreatorAndJoiner(page1, page2, { appUrl: APP_URL, signalingUrl: SIGNALING_URL });
 
-    await expect(page1.locator('#peerCount')).toHaveText('1', { timeout: 8000 });
-    await expect(page2.locator('#peerCount')).toHaveText('1', { timeout: 8000 });
+    await waitForPeerCount(page1, 1);
+    await waitForPeerCount(page2, 1);
 
     // Open the Debug tab on both peers, which renders the joinSequence as
     // an ordered ladder (debug_panel.js's joinSequenceHTML).


### PR DESCRIPTION
It duplicated state (table id, my id, connection dot, peer count) already tracked in app.js and only ever shown behind a hardcoded top-of-viewport bar. Removed the DOM node from index.html along with the app.js code that pushed values into it (the statusDot className toggles, updatePeerCount and its call sites).

e2e specs used #tableLabel/#peerCount as their peer-connected and table-landed wait conditions; those now poll App.getTableId() / App.getPeers() (already exposed on window.App) via new waitForTableId/waitForPeerCount helpers. hashchange.spec.js's mid-dialog case switches to a plain location.hash wait instead, since App.getTableId() doesn't settle until boot (and, for tt-T-v1-e2ehashtest, its join-intent dialog) resolves.


Claude-Session: https://claude.ai/code/session_014QJkzZpuuJr9pZ748Wqmxf